### PR TITLE
Add unit tests for category deletion

### DIFF
--- a/server/src/services/__test__/category/category.create.spec.ts
+++ b/server/src/services/__test__/category/category.create.spec.ts
@@ -4,7 +4,7 @@ import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { CreateCategoryValidator } from '../../category/decorator'
 import { checkRequestValidate } from '../test.utils'
 import { TypiaExceptionHandler } from 'src/common'
-import { CreateCategoryResponseType } from 'src/services/category/types'
+import { DefaultCategoryResponseType } from 'src/services/category/types'
 import { CategoryController, CategoryService } from 'src/services/category'
 
 describe('Testing Create Category', () => {
@@ -51,7 +51,7 @@ describe('Testing Create Category', () => {
       const result = new CreateCategoryValidator(request).validate()
       const created = await controller.createCategory(result)
 
-      expect(typia.equals<CreateCategoryResponseType>(created)).toBe(true)
+      expect(typia.equals<DefaultCategoryResponseType>(created)).toBe(true)
     })
 
     it('should throw error when sent wrong data', async () => {

--- a/server/src/services/__test__/category/category.delete.spec.ts
+++ b/server/src/services/__test__/category/category.delete.spec.ts
@@ -1,0 +1,91 @@
+import typia from 'typia'
+import { Test, TestingModule } from '@nestjs/testing'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { CategoryIdParamsValidator, CreateCategoryValidator } from '../../category/decorator'
+import { checkRequestValidate } from '../test.utils'
+import { TypiaExceptionHandler } from 'src/common'
+import { CategoryIdParamsDto, DefaultCategoryResponseType } from 'src/services/category/types'
+import { CategoryController, CategoryService } from 'src/services/category'
+
+describe('Testing Create Category', () => {
+  let controller: CategoryController
+  let service: CategoryService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoryController],
+      providers: [
+        {
+          provide: CategoryService,
+          useValue: {
+            softDeleteCategoryById: jest.fn()
+          }
+        }
+      ]
+    }).compile()
+
+    controller = module.get<CategoryController>(CategoryController)
+    service = module.get<CategoryService>(CategoryService)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('DELETE /soft/:categoryId', () => {
+    it('should return DefaultCategoryResponseType when successed call DELETE api', async () => {
+      const request: { params: CategoryIdParamsDto } = {
+        params: {
+          categoryId: '4f6c59f2-4978-4c4a-b276-5d3f8f1f8969'
+        }
+      }
+
+      jest.spyOn(service, 'softDeleteCategoryById').mockResolvedValue({
+        id: '4f6c59f2-4978-4c4a-b276-5d3f8f1f8969',
+        title: 'test title',
+        deleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      })
+
+      const result: CategoryIdParamsDto = new CategoryIdParamsValidator(request).validate()
+      const deleted = await controller.softDeleteCategoryById(result)
+
+      expect(typia.equals<DefaultCategoryResponseType>(deleted)).toBe(true)
+    })
+
+    it('should throw error when if sent categoryId of a type other than UUID', async () => {
+      const request: { params: CategoryIdParamsDto } = {
+        params: {
+          categoryId: '123'
+        }
+      }
+
+      const typiaError = await checkRequestValidate(CategoryIdParamsValidator, request)
+
+      try {
+        new TypiaExceptionHandler(typiaError.response).handleValidationError()
+      } catch (err) {
+        expect(err).toBeInstanceOf(BadRequestException)
+        expect(err.response.message).toBe(`Received unmatched data 'categoryId' [INVALID UUID TYPE ERROR]`)
+      }
+    })
+
+    it('should throw error when if sent categoryId of a type other than UUID', async () => {
+      const request: { params: CategoryIdParamsDto } = {
+        params: {
+          categoryId: ''
+        }
+      }
+
+      const typiaError = await checkRequestValidate(CategoryIdParamsValidator, request)
+
+      try {
+        new TypiaExceptionHandler(typiaError.response).handleValidationError()
+      } catch (err) {
+        expect(err).toBeInstanceOf(NotFoundException)
+        expect(err.response.message).toBe(`Received unexpected data 'categoryId' [MISSING DATA ERROR]`)
+      }
+    })
+  })
+})

--- a/server/src/services/__test__/category/category.get.spec.ts
+++ b/server/src/services/__test__/category/category.get.spec.ts
@@ -5,7 +5,7 @@ import { CategoryController, CategoryService } from '../../category'
 import { CategoryIdParamsValidator } from '../../category/decorator'
 import { checkRequestValidate } from '../test.utils'
 import { TypiaExceptionHandler } from 'src/common'
-import { CreateCategoryResponseType, GetCategoriesResponseType } from 'src/services/category/types'
+import { DefaultCategoryResponseType, GetCategoriesResponseType } from 'src/services/category/types'
 
 describe('Testing Get Category', () => {
   let controller: CategoryController
@@ -34,7 +34,7 @@ describe('Testing Get Category', () => {
 
   describe('GET /category', () => {
     it('should return GetCategoriesResponseType', async () => {
-      const mockCategories: CreateCategoryResponseType[] = [
+      const mockCategories: DefaultCategoryResponseType[] = [
         {
           id: '74cea9ab-6fe5-4a64-a3dd-ed91631bbcd6',
           title: 'Test Category 1',

--- a/server/src/services/category/category.controller.ts
+++ b/server/src/services/category/category.controller.ts
@@ -6,7 +6,7 @@ import {
   CategoryDeleteParamsDto,
   CategoryIdParamsDto,
   CreateCategoryDto,
-  CreateCategoryResponseType,
+  DefaultCategoryResponseType,
   GetCategoriesResponseType,
   UpdateCategoryDto,
   UpdateCategoryResponseType
@@ -19,7 +19,7 @@ export class CategoryController {
   constructor(private categoryService: CategoryService) {}
 
   @Post()
-  async createCategory(@ValidateCreateDTO() createCategoryDto: CreateCategoryDto): Promise<CreateCategoryResponseType> {
+  async createCategory(@ValidateCreateDTO() createCategoryDto: CreateCategoryDto): Promise<DefaultCategoryResponseType> {
     const { title } = createCategoryDto
     return this.categoryService.createCategory(title)
   }
@@ -46,7 +46,7 @@ export class CategoryController {
   }
 
   @Delete('/soft/:categoryId')
-  async softDeleteCategoryById(@ValidateIdParamDTO() deleteCategoryDto: CategoryIdParamsDto): Promise<Category> {
+  async softDeleteCategoryById(@ValidateIdParamDTO() deleteCategoryDto: CategoryIdParamsDto): Promise<DefaultCategoryResponseType> {
     const { categoryId } = deleteCategoryDto
     return this.categoryService.softDeleteCategoryById(categoryId)
   }

--- a/server/src/services/category/category.service.ts
+++ b/server/src/services/category/category.service.ts
@@ -5,7 +5,7 @@ import { CategoryRepository } from './category.repository'
 import {
   CategoryDeleteParamsDto,
   CreateCategory,
-  CreateCategoryResponseType,
+  DefaultCategoryResponseType,
   GetCategoriesResponseType,
   UpdateCategoryResponseType
 } from './types'
@@ -29,7 +29,7 @@ export class CategoryService {
     throw new NotFoundException(`The category you're looking for doesn't exist.`)
   }
 
-  async createCategory(title: string): Promise<CreateCategoryResponseType> {
+  async createCategory(title: string): Promise<DefaultCategoryResponseType> {
     const category: CreateCategory = {
       id: v4(),
       createdAt: new Date(),
@@ -75,7 +75,7 @@ export class CategoryService {
     return await this.saveCategory(updated)
   }
 
-  async softDeleteCategoryById(categoryId: string) {
+  async softDeleteCategoryById(categoryId: string): Promise<DefaultCategoryResponseType> {
     const category = await this.findCategoryById(categoryId)
     const updated: Category = { ...category, deleted: true }
     return this.saveCategory(updated)

--- a/server/src/services/category/types/response.type.ts
+++ b/server/src/services/category/types/response.type.ts
@@ -2,11 +2,11 @@ import { Category } from 'src/entities/category.entity'
 import { tags } from 'typia'
 
 export interface GetCategoriesResponseType {
-  data: CreateCategoryResponseType[]
+  data: DefaultCategoryResponseType[]
   total: number
 }
 
-export interface CreateCategoryResponseType {
+export interface DefaultCategoryResponseType {
   id: string & tags.Format<'uuid'>
   title: string
   createdAt: Date


### PR DESCRIPTION
Addtional work.
1. [Refactor response type names in category service](https://github.com/VVSOGI/todolist-remake/commit/676bf974714c42d7736f8ece1b074874ea13a348)
2. [Update import statements in category.create.spec.ts and category.get....](https://github.com/VVSOGI/todolist-remake/commit/b105e3a394e26e3f39629b7284c1e56d414b59bd)
3. [Refactor category controller and service to use DefaultCategoryRespon…](https://github.com/VVSOGI/todolist-remake/commit/69928414c91b3b87bc11c7ed86eef35cfb3f201d)