### PR TITLE
Add getCategoryById method and test case for getting category by ID

### DIFF
--- a/server/src/services/__test__/category/category.get.spec.ts
+++ b/server/src/services/__test__/category/category.get.spec.ts
@@ -2,10 +2,10 @@ import typia from 'typia'
 import { Test, TestingModule } from '@nestjs/testing'
 import { BadRequestException } from '@nestjs/common'
 import { CategoryController, CategoryService } from '../../category'
-import { CategoryIdParamsValidator } from '../../category/decorator'
 import { checkRequestValidate } from '../test.utils'
 import { TypiaExceptionHandler } from 'src/common'
 import { DefaultCategoryResponseType, GetCategoriesResponseType } from 'src/services/category/types'
+import { CategoryIdParamsValidator } from 'src/services/common'
 
 describe('Testing Get Category', () => {
   let controller: CategoryController

--- a/server/src/services/__test__/category/category.get.spec.ts
+++ b/server/src/services/__test__/category/category.get.spec.ts
@@ -18,7 +18,8 @@ describe('Testing Get Category', () => {
         {
           provide: CategoryService,
           useValue: {
-            getCategories: jest.fn()
+            getCategories: jest.fn(),
+            getCategoryById: jest.fn()
           }
         }
       ]
@@ -71,6 +72,29 @@ describe('Testing Get Category', () => {
   })
 
   describe('GET /category/:categoryId', () => {
+    it('should return DefaultCategoryResponseType', async () => {
+      const request = {
+        params: {
+          categoryId: '32e553e1-455f-4713-be2b-b71322cf5047'
+        }
+      }
+
+      const mockCategory: DefaultCategoryResponseType = {
+        id: request.params.categoryId,
+        title: 'Test Category 1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deleted: false
+      }
+
+      jest.spyOn(service, 'getCategoryById').mockResolvedValue(mockCategory)
+
+      const params = new CategoryIdParamsValidator(request).validate()
+      const result = await controller.getCategoryById(params)
+
+      expect(typia.equals<DefaultCategoryResponseType>(result)).toBe(true)
+    })
+
     it('should throw error when categoryId not matched uuid type', async () => {
       const request = {
         params: {

--- a/server/src/services/__test__/category/category.update.spec.ts
+++ b/server/src/services/__test__/category/category.update.spec.ts
@@ -1,11 +1,12 @@
 import typia from 'typia'
 import { Test, TestingModule } from '@nestjs/testing'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
-import { CategoryIdParamsValidator, UpdateCategoryValidator } from '../../category/decorator'
+import { UpdateCategoryValidator } from '../../category/decorator'
 import { checkRequestValidate } from '../test.utils'
 import { TypiaExceptionHandler } from 'src/common'
 import { UpdateCategoryResponseType } from 'src/services/category/types'
 import { CategoryController, CategoryService } from 'src/services/category'
+import { CategoryIdParamsValidator } from 'src/services/common'
 
 describe('Testing Update Category', () => {
   let controller: CategoryController

--- a/server/src/services/__test__/todolist/todolist.get.spec.ts
+++ b/server/src/services/__test__/todolist/todolist.get.spec.ts
@@ -7,6 +7,7 @@ import { BadRequestException } from '@nestjs/common'
 import { checkRequestValidate } from '../test.utils'
 import { TypiaExceptionHandler } from 'src/common'
 import { GetTodolistsResponseType, TodolistResponseType } from 'src/services/todolist/types'
+import { CategoryIdParamsValidator } from 'src/services/common'
 
 describe('Testing Get Todolist', () => {
   let controller: TodolistController
@@ -19,7 +20,8 @@ describe('Testing Get Todolist', () => {
         {
           provide: TodolistService,
           useValue: {
-            getTodolists: jest.fn()
+            getTodolists: jest.fn(),
+            getTodolistsByCategoryId: jest.fn()
           }
         }
       ]
@@ -92,6 +94,42 @@ describe('Testing Get Todolist', () => {
         expect(err).toBeInstanceOf(BadRequestException)
         expect(err.response.message).toBe(`Received unexpected data '(\"false\" | \"true\" | undefined)' [INVALID QUERY DATA ERROR]`)
       }
+    })
+  })
+
+  describe('GET /todolist/:categoryId', () => {
+    it('should return GetTodolistsResponseType', async () => {
+      const request = {
+        params: {
+          categoryId: '32e553e1-455f-4713-be2b-b71322cf5047'
+        },
+        query: {
+          checked: 'false'
+        }
+      }
+
+      const mockTodolists: TodolistResponseType[] = [
+        {
+          id: 'bfa7dc79-693d-431a-9eca-d65fc4dde7d2',
+          categoryId: '72f6e270-f7dd-418b-b932-0a7f187a211e',
+          order: 1,
+          title: 'mock todolist title 2',
+          checked: false,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      ]
+
+      jest.spyOn(service, 'getTodolistsByCategoryId').mockResolvedValue({
+        data: mockTodolists,
+        total: mockTodolists.length
+      })
+
+      const idParams = new CategoryIdParamsValidator(request).validate()
+      const checkedParams = new GetTodolistCheckedValidator(request).validate()
+      const result = await controller.getTodolistsByCategoryId(idParams, checkedParams)
+
+      expect(typia.equals<GetTodolistsResponseType>(result)).toBe(true)
     })
   })
 })

--- a/server/src/services/category/category.controller.ts
+++ b/server/src/services/category/category.controller.ts
@@ -30,7 +30,7 @@ export class CategoryController {
   }
 
   @Get(':categoryId')
-  async getCategoryById(@ValidateIdParamDTO() getCategoryDto: CategoryIdParamsDto): Promise<Category> {
+  async getCategoryById(@ValidateIdParamDTO() getCategoryDto: CategoryIdParamsDto): Promise<DefaultCategoryResponseType> {
     const { categoryId } = getCategoryDto
     return this.categoryService.getCategoryById(categoryId)
   }

--- a/server/src/services/category/category.controller.ts
+++ b/server/src/services/category/category.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Delete, Get, Patch, Post } from '@nestjs/common'
 import { ApiTags } from '@nestjs/swagger'
-import { Category } from 'src/entities'
 import { CategoryService } from './category.service'
 import {
   CategoryDeleteParamsDto,
@@ -11,7 +10,8 @@ import {
   UpdateCategoryDto,
   UpdateCategoryResponseType
 } from './types'
-import { ValidateCreateDTO, ValidateDeletedCheckedDTO, ValidateIdParamDTO, ValidateUpdateDTO } from './decorator'
+import { ValidateCreateDTO, ValidateDeletedCheckedDTO, ValidateUpdateDTO } from './decorator'
+import { ValidateIdParamDTO } from '../common'
 
 @ApiTags('Category')
 @Controller('category')

--- a/server/src/services/category/category.service.ts
+++ b/server/src/services/category/category.service.ts
@@ -42,7 +42,7 @@ export class CategoryService {
   }
 
   async updateDate(categoryId: string) {
-    const category = await this.getCategoryById(categoryId)
+    const category = await this.findCategoryById(categoryId)
     const updated: Category = { ...category, updatedAt: new Date() }
     this.saveCategory(updated)
   }
@@ -65,7 +65,7 @@ export class CategoryService {
     return this.categoryRepository.findAll(check)
   }
 
-  async getCategoryById(categoryId: string) {
+  async getCategoryById(categoryId: string): Promise<DefaultCategoryResponseType> {
     return await this.findCategoryById(categoryId)
   }
 

--- a/server/src/services/category/decorator/index.ts
+++ b/server/src/services/category/decorator/index.ts
@@ -1,5 +1,4 @@
 export * from './createCategory.decorator'
-export * from './validateIdParam.decorator'
 export * from './validator'
 export * from './deletedCheck.decorator'
 export * from './updateCategory.decorator'

--- a/server/src/services/category/decorator/validator/index.ts
+++ b/server/src/services/category/decorator/validator/index.ts
@@ -1,4 +1,3 @@
 export * from './createCategory.validator'
-export * from './categoryIdParam.validator'
 export * from './deleteCheck.validator'
 export * from './updateCategory.validator'

--- a/server/src/services/common/decorator/index.ts
+++ b/server/src/services/common/decorator/index.ts
@@ -1,0 +1,1 @@
+export * from './validateIdParam.decorator'

--- a/server/src/services/common/decorator/validateIdParam.decorator.ts
+++ b/server/src/services/common/decorator/validateIdParam.decorator.ts
@@ -1,6 +1,6 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common'
 import { TypiaExceptionHandler } from 'src/common'
-import { CategoryIdParamsValidator } from './validator'
+import { CategoryIdParamsValidator } from '../validator'
 
 export interface IdParamsRequest {
   params: {

--- a/server/src/services/common/index.ts
+++ b/server/src/services/common/index.ts
@@ -1,0 +1,3 @@
+export * from './decorator'
+export * from './validator'
+export * from './types'

--- a/server/src/services/common/types/index.ts
+++ b/server/src/services/common/types/index.ts
@@ -1,0 +1,1 @@
+export * from './params.type'

--- a/server/src/services/common/types/params.type.ts
+++ b/server/src/services/common/types/params.type.ts
@@ -1,0 +1,5 @@
+import { tags } from 'typia'
+
+export interface CategoryIdParamsDto {
+  categoryId: string & tags.Format<'uuid'>
+}

--- a/server/src/services/common/validator/categoryIdParam.validator.ts
+++ b/server/src/services/common/validator/categoryIdParam.validator.ts
@@ -1,8 +1,7 @@
 import typia from 'typia'
 import { BadRequestException } from '@nestjs/common'
 import { CustomIValidation } from 'src/common'
-import { CategoryIdParamsDto } from '../../types'
-import { IdParamsRequest } from '..'
+import { CategoryIdParamsDto, IdParamsRequest } from '..'
 
 export class CategoryIdParamsValidator {
   private params: CategoryIdParamsDto

--- a/server/src/services/common/validator/index.ts
+++ b/server/src/services/common/validator/index.ts
@@ -1,0 +1,1 @@
+export * from './categoryIdParam.validator'

--- a/server/src/services/todolist/todolist.controller.ts
+++ b/server/src/services/todolist/todolist.controller.ts
@@ -15,7 +15,7 @@ import {
   ValidateUpdateTodolistDto,
   ValidateUpdateTodolistOrderDTO
 } from './decorator'
-import { ValidateIdParamDTO } from '../common'
+import { CategoryIdParamsDto, ValidateIdParamDTO } from '../common'
 
 @Controller('todolist')
 export class TodolistController {
@@ -33,9 +33,10 @@ export class TodolistController {
 
   @Get(':categoryId')
   async getTodolistsByCategoryId(
-    @ValidateIdParamDTO() categoryId: string,
-    @ValidateGetTodolistCheckedDTO() checked: boolean
+    @ValidateIdParamDTO() getCategoryDto: CategoryIdParamsDto,
+    @ValidateGetTodolistCheckedDTO() checked?: boolean
   ): Promise<GetTodolistsResponseType> {
+    const { categoryId } = getCategoryDto
     return this.todolistService.getTodolistsByCategoryId({ categoryId, checked })
   }
 

--- a/server/src/services/todolist/todolist.controller.ts
+++ b/server/src/services/todolist/todolist.controller.ts
@@ -15,6 +15,7 @@ import {
   ValidateUpdateTodolistDto,
   ValidateUpdateTodolistOrderDTO
 } from './decorator'
+import { ValidateIdParamDTO } from '../common'
 
 @Controller('todolist')
 export class TodolistController {
@@ -32,7 +33,7 @@ export class TodolistController {
 
   @Get(':categoryId')
   async getTodolistsByCategoryId(
-    @Param('categoryId') categoryId: string,
+    @ValidateIdParamDTO() categoryId: string,
     @ValidateGetTodolistCheckedDTO() checked: boolean
   ): Promise<GetTodolistsResponseType> {
     return this.todolistService.getTodolistsByCategoryId({ categoryId, checked })

--- a/server/src/services/todolist/todolist.controller.ts
+++ b/server/src/services/todolist/todolist.controller.ts
@@ -7,7 +7,8 @@ import {
   GetTodolistsResponseType,
   UpdateTodolistDto,
   UpdateTodolistOrderDto,
-  UpdateTodolistsOrderResponseType
+  UpdateTodolistsOrderResponseType,
+  GetTodolistDto
 } from './types'
 import {
   ValidateCreateTodolistDTO,
@@ -34,10 +35,16 @@ export class TodolistController {
   @Get(':categoryId')
   async getTodolistsByCategoryId(
     @ValidateIdParamDTO() getCategoryDto: CategoryIdParamsDto,
-    @ValidateGetTodolistCheckedDTO() checked?: boolean
+    @ValidateGetTodolistCheckedDTO() checked?: GetTodolistDto
   ): Promise<GetTodolistsResponseType> {
     const { categoryId } = getCategoryDto
-    return this.todolistService.getTodolistsByCategoryId({ categoryId, checked })
+    let isChecked: boolean
+    if (checked === 'true') {
+      isChecked = true
+    } else {
+      isChecked = false
+    }
+    return this.todolistService.getTodolistsByCategoryId({ categoryId, checked: isChecked })
   }
 
   @Get('/dates/:categoryId')

--- a/server/src/services/todolist/todolist.service.ts
+++ b/server/src/services/todolist/todolist.service.ts
@@ -74,7 +74,7 @@ export class TodolistService {
     return target
   }
 
-  async getTodolistsByCategoryId(filters: GetTodolistDtoFilters) {
+  async getTodolistsByCategoryId(filters: GetTodolistDtoFilters): Promise<GetTodolistsResponseType> {
     const todolist = await this.todolistRepository.findByCategoryId(filters)
     return todolist
   }

--- a/server/src/services/todolist/types/get.type.ts
+++ b/server/src/services/todolist/types/get.type.ts
@@ -2,5 +2,5 @@ export type GetTodolistDto = 'true' | 'false' | undefined
 
 export interface GetTodolistDtoFilters {
   categoryId: string
-  checked: boolean
+  checked?: boolean
 }

--- a/server/src/services/todolist/types/get.type.ts
+++ b/server/src/services/todolist/types/get.type.ts
@@ -2,5 +2,5 @@ export type GetTodolistDto = 'true' | 'false' | undefined
 
 export interface GetTodolistDtoFilters {
   categoryId: string
-  checked?: boolean
+  checked: boolean
 }


### PR DESCRIPTION
Addtional work.
1. [Update return type of getCategoryById method](https://github.com/VVSOGI/todolist-remake/commit/7b393b2b58b3288f925442725ccd7da0a98838f0)
2. [Move categoryId Validator to common decorator](https://github.com/VVSOGI/todolist-remake/commit/fb394360f6a96b2f888e1e06679de92130a7a2a9)
3. [Add CategoryIdParamsDto to TodolistController](https://github.com/VVSOGI/todolist-remake/commit/067421606f867bae40487ef4dcbaefabced91548)
4. [Fix getTodolistsByCategoryId checked parameter type](https://github.com/VVSOGI/todolist-remake/commit/48c0a0856a29972838c7aeed11f893c8ff679852)
5. [Add testcase GET /todolist/:categoryId](https://github.com/VVSOGI/todolist-remake/commit/edf033e4502fabb6e8673a653fa6dbb02e9338bb) https://github.com/VVSOGI/todolist-remake/issues/43