### PR TITLE
Add test case for getting todolists by dates

### DIFF
--- a/server/src/services/__test__/todolist/todolist.get.spec.ts
+++ b/server/src/services/__test__/todolist/todolist.get.spec.ts
@@ -203,5 +203,22 @@ describe('Testing Get Todolist', () => {
 
       expect(typia.equals<GetTodolistsResponseType>(result)).toBe(true)
     })
+
+    it('should throw error when if sent id of a type other than UUID', async () => {
+      const request = {
+        params: {
+          categoryId: '111'
+        }
+      }
+
+      const typiaError = await checkRequestValidate(CategoryIdParamsValidator, request)
+
+      try {
+        new TypiaExceptionHandler(typiaError.response).handleValidationError()
+      } catch (err) {
+        expect(err).toBeInstanceOf(BadRequestException)
+        expect(err.response.message).toBe(`Received unmatched data 'categoryId' [INVALID UUID TYPE ERROR]`)
+      }
+    })
   })
 })

--- a/server/src/services/__test__/todolist/todolist.get.spec.ts
+++ b/server/src/services/__test__/todolist/todolist.get.spec.ts
@@ -131,7 +131,48 @@ describe('Testing Get Todolist', () => {
 
       expect(typia.equals<GetTodolistsResponseType>(result)).toBe(true)
     })
+
+    it('should throw error when if sent id of a type other than UUID', async () => {
+      const request = {
+        params: {
+          categoryId: '123'
+        },
+        query: {
+          checked: 'false'
+        }
+      }
+
+      const typiaError = await checkRequestValidate(CategoryIdParamsValidator, request)
+
+      try {
+        new TypiaExceptionHandler(typiaError.response).handleValidationError()
+      } catch (err) {
+        expect(err).toBeInstanceOf(BadRequestException)
+        expect(err.response.message).toBe(`Received unmatched data 'categoryId' [INVALID UUID TYPE ERROR]`)
+      }
+    })
+
+    it('should throw error when if sent wrong data that query checked', async () => {
+      const request = {
+        params: {
+          categoryId: '32e553e1-455f-4713-be2b-b71322cf5047'
+        },
+        query: {
+          checked: ''
+        }
+      }
+
+      const typiaError = await checkRequestValidate(GetTodolistCheckedValidator, request)
+
+      try {
+        new TypiaExceptionHandler(typiaError.response).handleValidationError()
+      } catch (err) {
+        expect(err).toBeInstanceOf(BadRequestException)
+        expect(err.response.message).toBe(`Received unexpected data '(\"false\" | \"true\" | undefined)' [INVALID QUERY DATA ERROR]`)
+      }
+    })
   })
+
   describe('GET /todolist/dates/:categoryId', () => {
     it('should return GetTodolistsResponseType', async () => {
       const request = {

--- a/server/src/services/__test__/todolist/todolist.get.spec.ts
+++ b/server/src/services/__test__/todolist/todolist.get.spec.ts
@@ -132,4 +132,35 @@ describe('Testing Get Todolist', () => {
       expect(typia.equals<GetTodolistsResponseType>(result)).toBe(true)
     })
   })
+  describe('GET /todolist/dates/:categoryId', () => {
+    it('should return GetTodolistsResponseType', async () => {
+      const request = {
+        params: {
+          categoryId: '32e553e1-455f-4713-be2b-b71322cf5047'
+        }
+      }
+
+      const mockTodolists: TodolistResponseType[] = [
+        {
+          id: 'bfa7dc79-693d-431a-9eca-d65fc4dde7d2',
+          categoryId: '72f6e270-f7dd-418b-b932-0a7f187a211e',
+          order: 1,
+          title: 'mock todolist title 2',
+          checked: false,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      ]
+
+      jest.spyOn(service, 'getTodolistsByCategoryId').mockResolvedValue({
+        data: mockTodolists,
+        total: mockTodolists.length
+      })
+
+      const idParams = new CategoryIdParamsValidator(request).validate()
+      const result = await controller.getTodolistsByCategoryId(idParams)
+
+      expect(typia.equals<GetTodolistsResponseType>(result)).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
Addtional work.
1. [Add validation tests for Get Todolist with categoryId](https://github.com/VVSOGI/todolist-remake/commit/30f10122a44da19f3d7401739aedd1d44a0133ae)
2. [Add test case for handling invalid UUID type in Get Todolist with dates ](https://github.com/VVSOGI/todolist-remake/commit/8d2b42c716613c7faf0ef9fa93c6cb09359d7b1c)
