### PR TITLE
Remove hover state for optimization performance.

### DIFF
--- a/client/app/ui/todolist/TodoItem.tsx
+++ b/client/app/ui/todolist/TodoItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo } from 'react'
 import styled from 'styled-components'
 import { BORDER_RADIUS_SIZES, colors } from '@/app/styles'
 import { CheckCircle } from '@/app/ui'
@@ -68,7 +68,7 @@ interface Props {
   handleEditModalOpen: (todo: Todo) => void
 }
 
-export function TodoItem({ todo, handleCompleteTodo, handleEditModalOpen }: Props) {
+function TodoItemComponent({ todo, handleCompleteTodo, handleEditModalOpen }: Props) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: todo.id })
 
   return (
@@ -91,3 +91,5 @@ export function TodoItem({ todo, handleCompleteTodo, handleEditModalOpen }: Prop
     </TodoWrapper>
   )
 }
+
+export const TodoItem = memo(TodoItemComponent)

--- a/client/app/utils/hooks/drag/useDragDndKit.ts
+++ b/client/app/utils/hooks/drag/useDragDndKit.ts
@@ -17,7 +17,6 @@ interface CustomDragEndEvent extends DragEndEvent {
 
 export function useDragDndKit<T>({ list, setList }: Props<T>) {
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null)
-
   const activeItem = useMemo(() => list.find((item) => item.id === activeId), [activeId, list])
 
   const sensors = useSensors(


### PR DESCRIPTION
I should have pushed this branch with the commits below, but I accidentally pushed it to main, so I'm writing a PR instead.

This pull request is coded for optimizations. I want to avoid unnecessary rendering of the Draggable list as much as possible, but I'm not sure how to go about it yet. I started by fixing the easiest problem, the hovering effect, which currently causes the most unnecessary re-renders. 

The hovering effect was previously controlled by JavaScript, but since it renders on mouse hover, I ended up handing off the responsibility to CSS. While I was tweaking the CSS, I also did some additional code cleanup.

[Remove hover state for optimization performance.](https://github.com/VVSOGI/todolist-remake/commit/5c5de92e3ea6e77e3d1b16f1e6cabf86b3e2752f) https://github.com/VVSOGI/todolist-remake/issues/87
[Add CSS hover effect to TodoWrapper instead of javascript hovering](https://github.com/VVSOGI/todolist-remake/commit/3b51b40a52a80f9788872585feed1c34aac69875) https://github.com/VVSOGI/todolist-remake/issues/87