### PR TITLE
Add middleware for redirecting root path to category #91

### DIFF
--- a/client/middleware.ts
+++ b/client/middleware.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === '/') {
+    return NextResponse.redirect(new URL(`/category`, request.url))
+  }
+}
+
+export const config = {
+  // Matcher ignoring `/_next/` and `/api/`
+  matcher: '/((?!api|static|locales|.*\\..*|_next).*)'
+}


### PR DESCRIPTION
This pull request is a PR that adds middleware to automatically route to /category when the app is accessed. The details are as follows line.

Create middleware to route first page to /category #91