### PR TITLE
Change router push to Link components in TodolistHeader, StorageHeader

### DIFF
--- a/client/app/ui/storage/StorageHeader.tsx
+++ b/client/app/ui/storage/StorageHeader.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components'
+import Link from 'next/link'
 import { Title } from '@/app/ui'
 import { Category } from '@/app/types'
 import { changeToLocaleTime } from '@/app/utils'
 import { TODOLIST_HEIGHTS, colors } from '@/app/styles'
 import { useRouter } from 'next/navigation'
+import { IoIosClose } from 'react-icons/io'
 
 const Header = styled.div`
   height: ${TODOLIST_HEIGHTS.HEADER};
@@ -18,34 +20,29 @@ const Time = styled.div`
   font-size: 0.75rem;
 `
 
-const IconsWrapper = styled.div`
+const IconsWrapper = styled(Link)`
+  width: 2.5rem;
+  height: 2.5rem;
   display: flex;
+  justify-content: center;
   align-items: center;
   gap: 0.75rem;
+  border-radius: 50%;
+  cursor: pointer;
 
-  button {
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 50%;
+  &:hover {
+    background-color: ${colors.gray_100};
+    color: ${colors.red_400};
+  }
+
+  &:active {
+    background-color: ${colors.white};
+    color: ${colors.red_500};
+  }
+
+  svg {
+    font-size: 1.8rem;
     color: ${colors.red_600};
-    font-weight: 800;
-    font-size: 1.125rem;
-    cursor: pointer;
-
-    &:hover {
-      background-color: ${colors.gray_100};
-      color: ${colors.red_400};
-    }
-
-    &:active {
-      background-color: ${colors.white};
-      color: ${colors.red_500};
-    }
-
-    svg {
-      font-size: 0.875rem;
-      color: ${colors.black};
-    }
   }
 `
 
@@ -56,18 +53,14 @@ interface Props {
 export function StorageHeader({ category }: Props) {
   const router = useRouter()
 
-  const moveBackPage = () => {
-    router.push(`/${category.id}`)
-  }
-
   return (
     <Header>
       <div>
         <Title style={{ margin: 0, fontSize: '1.5rem' }}>{category.title.toUpperCase()}</Title>
         <Time>{changeToLocaleTime(category.updatedAt)}</Time>
       </div>
-      <IconsWrapper>
-        <button onClick={moveBackPage}>X</button>
+      <IconsWrapper href={`/todolist/${category.id}`}>
+        <IoIosClose />
       </IconsWrapper>
     </Header>
   )

--- a/client/app/ui/storage/StorageHeader.tsx
+++ b/client/app/ui/storage/StorageHeader.tsx
@@ -4,7 +4,7 @@ import { Title } from '@/app/ui'
 import { Category } from '@/app/types'
 import { changeToLocaleTime } from '@/app/utils'
 import { TODOLIST_HEIGHTS, colors } from '@/app/styles'
-import { IoIosClose } from 'react-icons/io'
+import { IoClose } from 'react-icons/io5'
 
 const Header = styled.div`
   height: ${TODOLIST_HEIGHTS.HEADER};
@@ -19,7 +19,7 @@ const Time = styled.div`
   font-size: 0.75rem;
 `
 
-const IconsWrapper = styled(Link)`
+const LinkWrapper = styled(Link)`
   width: 2.5rem;
   height: 2.5rem;
   display: flex;
@@ -31,16 +31,17 @@ const IconsWrapper = styled(Link)`
 
   &:hover {
     background-color: ${colors.gray_100};
-    color: ${colors.red_400};
   }
 
   &:active {
     background-color: ${colors.white};
-    color: ${colors.red_500};
+    svg {
+      color: ${colors.red_500};
+    }
   }
 
   svg {
-    font-size: 1.8rem;
+    font-size: 1.25rem;
     color: ${colors.red_600};
   }
 `
@@ -56,9 +57,9 @@ export function StorageHeader({ category }: Props) {
         <Title style={{ margin: 0, fontSize: '1.5rem' }}>{category.title.toUpperCase()}</Title>
         <Time>{changeToLocaleTime(category.updatedAt)}</Time>
       </div>
-      <IconsWrapper href={`/todolist/${category.id}`}>
-        <IoIosClose />
-      </IconsWrapper>
+      <LinkWrapper href={`/todolist/${category.id}`}>
+        <IoClose />
+      </LinkWrapper>
     </Header>
   )
 }

--- a/client/app/ui/storage/StorageHeader.tsx
+++ b/client/app/ui/storage/StorageHeader.tsx
@@ -4,7 +4,6 @@ import { Title } from '@/app/ui'
 import { Category } from '@/app/types'
 import { changeToLocaleTime } from '@/app/utils'
 import { TODOLIST_HEIGHTS, colors } from '@/app/styles'
-import { useRouter } from 'next/navigation'
 import { IoIosClose } from 'react-icons/io'
 
 const Header = styled.div`
@@ -51,8 +50,6 @@ interface Props {
 }
 
 export function StorageHeader({ category }: Props) {
-  const router = useRouter()
-
   return (
     <Header>
       <div>

--- a/client/app/ui/todolist/TodolistHeader.tsx
+++ b/client/app/ui/todolist/TodolistHeader.tsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components'
-import { useRouter } from 'next/navigation'
-import { FaBox } from 'react-icons/fa'
+import Link from 'next/link'
 import { Title } from '@/app/ui'
 import { Category } from '@/app/types'
 import { changeToLocaleTime } from '@/app/utils'
 import { TODOLIST_HEIGHTS, colors } from '@/app/styles'
+import { FaBox } from 'react-icons/fa'
+import { IoClose } from 'react-icons/io5'
 
 const Header = styled.div`
   height: ${TODOLIST_HEIGHTS.HEADER};
@@ -25,30 +26,31 @@ const IconsWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 0.75rem;
+`
 
-  button {
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 50%;
-    color: ${colors.red_600};
-    font-weight: 800;
-    font-size: 1.125rem;
-    cursor: pointer;
+const LinkWrapper = styled(Link)`
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 50%;
+  cursor: pointer;
 
-    &:hover {
-      background-color: ${colors.gray_100};
-      color: ${colors.red_400};
-    }
+  &:hover {
+    background-color: ${colors.gray_100};
+  }
 
-    &:active {
-      background-color: ${colors.white};
+  &:active {
+    background-color: ${colors.white};
+    svg {
       color: ${colors.red_500};
     }
+  }
 
-    svg {
-      font-size: 0.875rem;
-      color: ${colors.black};
-    }
+  svg {
+    color: ${colors.red_600};
   }
 `
 
@@ -57,17 +59,6 @@ interface Props {
 }
 
 export function TodolistHeader({ category }: Props) {
-  const router = useRouter()
-
-  const moveStorage = () => {
-    router.push(`/storage/${category.id}`)
-  }
-
-  const moveBackPage = () => {
-    router.push('/')
-    router.refresh()
-  }
-
   return (
     <Header>
       <div>
@@ -75,10 +66,12 @@ export function TodolistHeader({ category }: Props) {
         <Time>{changeToLocaleTime(category.updatedAt)}</Time>
       </div>
       <IconsWrapper>
-        <button onClick={moveStorage}>
+        <LinkWrapper href={`/storage/${category.id}`}>
           <FaBox />
-        </button>
-        <button onClick={moveBackPage}>X</button>
+        </LinkWrapper>
+        <LinkWrapper href={`/`}>
+          <IoClose fontSize={`1.25rem`} />
+        </LinkWrapper>
       </IconsWrapper>
     </Header>
   )


### PR DESCRIPTION
This pull request includes changes to the `StorageHeader` and `TodolistHeader` components to replace the use of the `useRouter` hook with `Link` from `next/link` for navigation. Additionally, the `IoClose` icon from `react-icons/io5` has been introduced for better styling.

Navigation improvements:

* [`client/app/ui/storage/StorageHeader.tsx`](diffhunk://#diff-431fa52b0770435aa605883e8bd711fd79422407ef19b9bfe91ae4b149ce9ac9R2-R7): Replaced `useRouter` with `Link` for navigation and updated the `IconsWrapper` to `LinkWrapper` for better styling and navigation. 
* [`client/app/ui/todolist/TodolistHeader.tsx`](diffhunk://#diff-30c162819729fd9328d8114cb609486f7aadac15a23ca901d13c2ce6563e97faL2-R8): Replaced `useRouter` with `Link` for navigation and updated the `IconsWrapper` to `LinkWrapper` for better styling and navigation.

Change all route push to Link components #94
