### PR TITLE
Update story names by numbering for different viewports

### DIFF
--- a/client/app/stories/category/Categories.stories.tsx
+++ b/client/app/stories/category/Categories.stories.tsx
@@ -45,7 +45,7 @@ type Story = StoryObj<typeof categories>
 /**
  * 가장 기본적인 화면의 Categories 입니다.
  */
-export const StylesTablet: Story = {
+export const Styles1Tablet: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'tablet'
@@ -55,7 +55,7 @@ export const StylesTablet: Story = {
   args: {}
 }
 
-export const StylesDesktop: Story = {
+export const Styles2Desktop: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'desktop'
@@ -65,7 +65,7 @@ export const StylesDesktop: Story = {
   args: {}
 }
 
-export const StylesMobile: Story = {
+export const Styles3Mobile: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'iphone14'

--- a/client/app/stories/category/CategorySection.stories.tsx
+++ b/client/app/stories/category/CategorySection.stories.tsx
@@ -39,7 +39,7 @@ type Story = StoryObj<typeof categorySection>
 /**
  * 가장 기본적인 형태의 CategorySection 입니다.
  */
-export const StylesTablet: Story = {
+export const Styles1Tablet: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'tablet'
@@ -49,7 +49,7 @@ export const StylesTablet: Story = {
   args: {}
 }
 
-export const StylesDesktop: Story = {
+export const Styles2Desktop: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'desktop'
@@ -59,7 +59,7 @@ export const StylesDesktop: Story = {
   args: {}
 }
 
-export const StylesMobile: Story = {
+export const Styles3Mobile: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'iphone14'

--- a/client/app/stories/category/CreateCategory.stories.tsx
+++ b/client/app/stories/category/CreateCategory.stories.tsx
@@ -43,7 +43,7 @@ type Story = StoryObj<typeof createCategory>
 /**
  * 가장 기본적인 형태의 CreateCategory입니다.
  */
-export const StylesTablet: Story = {
+export const Styles1Tablet: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'tablet'
@@ -53,7 +53,7 @@ export const StylesTablet: Story = {
   args: {}
 }
 
-export const StylesDesktop: Story = {
+export const Styles2Desktop: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'desktop'
@@ -63,7 +63,7 @@ export const StylesDesktop: Story = {
   args: {}
 }
 
-export const StylesMobile: Story = {
+export const Styles3Mobile: Story = {
   parameters: {
     viewport: {
       defaultViewport: 'iphone14'

--- a/client/app/stories/category/useCases/CategoryPage.stories.tsx
+++ b/client/app/stories/category/useCases/CategoryPage.stories.tsx
@@ -33,7 +33,7 @@ const categoryPage = {
 export default categoryPage
 type Story = StoryObj<typeof categoryPage>
 
-export const StylesTablet: Story = {
+export const Styles1Tablet: Story = {
   args: {},
   parameters: {
     viewport: {
@@ -42,7 +42,7 @@ export const StylesTablet: Story = {
   }
 }
 
-export const StylesDesktop: Story = {
+export const Styles2Desktop: Story = {
   args: {},
   parameters: {
     viewport: {
@@ -51,7 +51,7 @@ export const StylesDesktop: Story = {
   }
 }
 
-export const StylesMobile: Story = {
+export const Styles3Mobile: Story = {
   args: {},
   parameters: {
     viewport: {

--- a/client/app/stories/components/Modal.stories.tsx
+++ b/client/app/stories/components/Modal.stories.tsx
@@ -36,7 +36,7 @@ const meta = {
 
 type Story = StoryObj<typeof meta>
 
-export const StylesTablet: Story = {
+export const Styles1Tablet: Story = {
   args: {},
   parameters: {
     viewport: {
@@ -46,7 +46,7 @@ export const StylesTablet: Story = {
   tags: ['autodocs']
 }
 
-export const StylesDesktop: Story = {
+export const Styles2Desktop: Story = {
   args: {},
   parameters: {
     viewport: {
@@ -55,7 +55,7 @@ export const StylesDesktop: Story = {
   }
 }
 
-export const StylesMobile: Story = {
+export const Styles3Mobile: Story = {
   args: {},
   parameters: {
     viewport: {


### PR DESCRIPTION
This pull request includes changes to the story files in the `client/app/stories` directory to rename the `StylesTablet`, `StylesDesktop`, and `StylesMobile` story objects to `Styles1Tablet`, `Styles2Desktop`, and `Styles3Mobile`, respectively. These changes ensure ['tablet', 'desktop', 'mobile'] orders

Changes to story object names:

* [`client/app/stories/category/Categories.stories.tsx`](diffhunk://#diff-f43dba2f3a952012107fe989763d6a045422f5110d8ff14aeff9ae34b3233ecfL48-R48): Renamed `StylesTablet`, `StylesDesktop`, and `StylesMobile` to `Styles1Tablet`, `Styles2Desktop`, and `Styles3Mobile`. [[1]](diffhunk://#diff-f43dba2f3a952012107fe989763d6a045422f5110d8ff14aeff9ae34b3233ecfL48-R48) [[2]](diffhunk://#diff-f43dba2f3a952012107fe989763d6a045422f5110d8ff14aeff9ae34b3233ecfL58-R58) [[3]](diffhunk://#diff-f43dba2f3a952012107fe989763d6a045422f5110d8ff14aeff9ae34b3233ecfL68-R68)
* [`client/app/stories/category/CategorySection.stories.tsx`](diffhunk://#diff-662441ad7c883ff76f18a5bf13f1d77ebfd5702ffd57216d384f36b350258746L42-R42): Renamed `StylesTablet`, `StylesDesktop`, and `StylesMobile` to `Styles1Tablet`, `Styles2Desktop`, and `Styles3Mobile`. [[1]](diffhunk://#diff-662441ad7c883ff76f18a5bf13f1d77ebfd5702ffd57216d384f36b350258746L42-R42) [[2]](diffhunk://#diff-662441ad7c883ff76f18a5bf13f1d77ebfd5702ffd57216d384f36b350258746L52-R52) [[3]](diffhunk://#diff-662441ad7c883ff76f18a5bf13f1d77ebfd5702ffd57216d384f36b350258746L62-R62)
* [`client/app/stories/category/CreateCategory.stories.tsx`](diffhunk://#diff-ae2bc5182876cadf22a470dab3fe1109c3dd2cedffa158c4d803399a41f7a1a3L46-R46): Renamed `StylesTablet`, `StylesDesktop`, and `StylesMobile` to `Styles1Tablet`, `Styles2Desktop`, and `Styles3Mobile`. [[1]](diffhunk://#diff-ae2bc5182876cadf22a470dab3fe1109c3dd2cedffa158c4d803399a41f7a1a3L46-R46) [[2]](diffhunk://#diff-ae2bc5182876cadf22a470dab3fe1109c3dd2cedffa158c4d803399a41f7a1a3L56-R56) [[3]](diffhunk://#diff-ae2bc5182876cadf22a470dab3fe1109c3dd2cedffa158c4d803399a41f7a1a3L66-R66)
* [`client/app/stories/category/useCases/CategoryPage.stories.tsx`](diffhunk://#diff-eed83b424f8f740ba8c18b559ea180327a4dbe18219933e4509faf912c700b7dL36-R36): Renamed `StylesTablet`, `StylesDesktop`, and `StylesMobile` to `Styles1Tablet`, `Styles2Desktop`, and `Styles3Mobile`. [[1]](diffhunk://#diff-eed83b424f8f740ba8c18b559ea180327a4dbe18219933e4509faf912c700b7dL36-R36) [[2]](diffhunk://#diff-eed83b424f8f740ba8c18b559ea180327a4dbe18219933e4509faf912c700b7dL45-R45) [[3]](diffhunk://#diff-eed83b424f8f740ba8c18b559ea180327a4dbe18219933e4509faf912c700b7dL54-R54)
* [`client/app/stories/components/Modal.stories.tsx`](diffhunk://#diff-a7070fd7e6f8eab210016e811971ba0ac7d7258e6b629098e65a173c22bbd91bL39-R39): Renamed `StylesTablet`, `StylesDesktop`, and `StylesMobile` to `Styles1Tablet`, `Styles2Desktop`, and `Styles3Mobile`. [[1]](diffhunk://#diff-a7070fd7e6f8eab210016e811971ba0ac7d7258e6b629098e65a173c22bbd91bL39-R39) [[2]](diffhunk://#diff-a7070fd7e6f8eab210016e811971ba0ac7d7258e6b629098e65a173c22bbd91bL49-R49) [[3]](diffhunk://#diff-a7070fd7e6f8eab210016e811971ba0ac7d7258e6b629098e65a173c22bbd91bL58-R58)