### PR TITLE
Add TodolistMain component and its stories

### DIFF
--- a/client/app/stories/todolist/TodolistMain.stories.tsx
+++ b/client/app/stories/todolist/TodolistMain.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Container, TodolistMain } from '@/app/ui'
+
+const todolistMain = {
+  title: 'Example/Todolist/TodolistMain',
+  component: TodolistMain,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: '투두리스트의 섹션 입니다. \n\n 해당 섹션에는 TodolistHeader, TodolistSection을 배치합니다.'
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    children: ''
+  },
+  decorators: (Story) => (
+    <Container>
+      <Story />
+    </Container>
+  )
+} satisfies Meta<typeof TodolistMain>
+
+export default todolistMain
+type Story = StoryObj<typeof todolistMain>
+
+/**
+ * 가장 기본적인 형태의 todolistMain 입니다.
+ */
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  args: {}
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}


### PR DESCRIPTION
This pull request introduces a new Storybook configuration for the `TodolistMain` component in the `client/app/stories/todolist/TodolistMain.stories.tsx` file. The changes include the addition of meta information, story definitions, and viewport-specific configurations.

Key changes include:

* Added import statements for `Meta` and `StoryObj` from `@storybook/react` and the `Container` and `TodolistMain` components from the project's UI module.
* Defined a `todolistMain` object with metadata, including title, component, parameters, and decorators, to configure the Storybook story for `TodolistMain`.
* Exported the default `todolistMain` object and created a `Story` type alias for the story object.
* Added three story variations (`Styles1Tablet`, `Styles2Desktop`, `Styles3Mobile`) with different viewport settings and tags to demonstrate the `TodolistMain` component in various screen sizes.