### PR TITLE
Add TodoItem components to stories, mock data

### DIFF
--- a/client/app/stories/mock/todolist.ts
+++ b/client/app/stories/mock/todolist.ts
@@ -1,0 +1,31 @@
+import { Todo } from '@/app/types'
+
+export const mockTodoItems: Todo[] = [
+  {
+    id: '1',
+    categoryId: '2',
+    title: 'Test todo item title 1',
+    checked: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    order: 0
+  },
+  {
+    id: '2',
+    categoryId: '2',
+    title: 'Test todo item title 2',
+    checked: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    order: 1
+  },
+  {
+    id: '3',
+    categoryId: '2',
+    title: 'Test todo item title 3',
+    checked: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    order: 2
+  }
+]

--- a/client/app/stories/todolist/TodoItem.stories.tsx
+++ b/client/app/stories/todolist/TodoItem.stories.tsx
@@ -1,0 +1,66 @@
+import { Container, TodoItem, TodolistSection } from '@/app/ui'
+import { mockTodoItems } from '../mock/todolist'
+import { fn } from '@storybook/test'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const todolistMain = {
+  title: 'Example/Todolist/TodoItem',
+  component: TodoItem,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: '투두리스트의 섹션 입니다. \n\n 해당 섹션에는 TodolistHeader, TodolistSection을 배치합니다.'
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    todo: mockTodoItems[0],
+    handleCompleteTodo: fn(),
+    handleEditModalOpen: fn()
+  },
+  decorators: (Story) => (
+    <Container>
+      <TodolistSection>
+        <Story />
+      </TodolistSection>
+    </Container>
+  )
+} satisfies Meta<typeof TodoItem>
+
+export default todolistMain
+type Story = StoryObj<typeof todolistMain>
+
+/**
+ * 가장 기본적인 형태의 TodoItem 입니다.
+ */
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  args: {}
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}

--- a/client/app/stories/todolist/TodolistSection.stories.tsx
+++ b/client/app/stories/todolist/TodolistSection.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/react'
 import { Container, TodolistSection } from '@/app/ui'
+import type { Meta, StoryObj } from '@storybook/react'
 
 const todolistMain = {
   title: 'Example/Todolist/TodolistSection',


### PR DESCRIPTION
This pull request introduces add new stories todolist component that 'TodoItem'. and also add mock data for TodoItem in process.

### Mock Data Addition:
* [`client/app/stories/mock/todolist.ts`](diffhunk://#diff-fd62e508bff2539b994e352c0e135a4db7a4e6aa4ee487cfecd8d24331da20f1R1-R31): Added a mock todo items array to be used in Storybook stories.

### Storybook Stories Update:
* [`client/app/stories/todolist/TodoItem.stories.tsx`](diffhunk://#diff-87ae5c88bee5a3aba02e5d5b2c68e6abdb08c24881b6466b914c1049b65cf362R1-R66): Created new stories for the `TodoItem` component with different viewports (tablet, desktop, mobile) and added a decorator for consistent layout.
* [`client/app/stories/todolist/TodolistSection.stories.tsx`](diffhunk://#diff-978ece62d180e677dd51f69f472fce2cc71c0b433262f27b4a13db643ffec210L1-R2): Reorganized import statements for better readability.