### PR TITLE
Add DraggableTodolist component and its stories

### DIFF
--- a/client/app/stories/todolist/DraggableTodolist.stories.tsx
+++ b/client/app/stories/todolist/DraggableTodolist.stories.tsx
@@ -1,0 +1,72 @@
+import { Container, DraggableTodolist, TodolistSection } from '@/app/ui'
+import { mockTodoItems } from '../mock/todolist'
+import { fn } from '@storybook/test'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const draggableTodolist = {
+  title: 'Example/Todolist/DraggableTodolist',
+  component: DraggableTodolist,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `드래그를 사용하는 컴포넌트 부분인 DraggableTodolist 입니다.
+        \n\n 이 스토리 컴포넌트는 실제로 드래그 기능이 동작하지 않습니다. 움직임이나 경험을 미리 체험할 수 있게끔만 작성되었습니다.
+        \n\n 현재 Docs에서 드래그 기능을 사용하면 마우스의 위치값과 컴포넌트의 위치가 맞지 않는 상황이 발생합니다.
+        \n\n 이는 Docs가 iframe으로 생성되기에 실제 마우스의 위치와 iframe html이 인식하는 마우스의 위치가 다르기에 발생하는 문제로 추측됩니다.
+        \n\n 따라서 사용을 해보기 위해서는 좌측 Styles Tablet, Desktop, Moblie에서 사용하시는 것을 권장드립니다.
+        `
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    list: mockTodoItems,
+    setList: fn(),
+    handleCompleteTodo: fn(),
+    handleEditModalOpen: fn()
+  },
+  decorators: (Story) => (
+    <Container>
+      <TodolistSection>
+        <Story />
+      </TodolistSection>
+    </Container>
+  )
+} satisfies Meta<typeof DraggableTodolist>
+
+export default draggableTodolist
+type Story = StoryObj<typeof draggableTodolist>
+
+/**
+ * 가장 기본적인 형태의 DraggableTodolist 입니다.
+ */
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  args: {}
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}

--- a/client/app/stories/todolist/TodoItem.stories.tsx
+++ b/client/app/stories/todolist/TodoItem.stories.tsx
@@ -10,7 +10,8 @@ const todolistMain = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component: '투두리스트의 섹션 입니다. \n\n 해당 섹션에는 TodolistHeader, TodolistSection을 배치합니다.'
+        component:
+          '투두리스트에 들어가는 1 개의 TodoItem입니다. \n\n 해당 아이템은 Hover 이벤트와 Checked 클릭 이벤트를 사용할 수 있습니다.'
       }
     }
   },


### PR DESCRIPTION
This pull request includes updates to the storybook configuration for the `Todolist` components, specifically adding a new story for `DraggableTodolist`.

New story for `DraggableTodolist`:

* [`client/app/stories/todolist/DraggableTodolist.stories.tsx`](diffhunk://#diff-72e354df29560408ea88a8d85948ef226b07b4a62666cd435592e1c8367f857dR1-R72): Added a new story configuration for `DraggableTodolist`, including parameters, decorators, and three viewport-specific styles (tablet, desktop, mobile). The story includes mock data and placeholder functions for `list`, `setList`, `handleCompleteTodo`, and `handleEditModalOpen`.

Updated description for `TodoItem`:

* [`client/app/stories/todolist/TodoItem.stories.tsx`](diffhunk://#diff-87ae5c88bee5a3aba02e5d5b2c68e6abdb08c24881b6466b914c1049b65cf362L13-R14): Updated the component description in the story configuration to reflect that it represents a single `TodoItem` with hover and click events.