### PR TITLE
Add TodolistHeader component and its stories #39

### DIFF
--- a/client/app/stories/todolist/TodolistHeader.stories.tsx
+++ b/client/app/stories/todolist/TodolistHeader.stories.tsx
@@ -1,0 +1,66 @@
+import { Container, TodolistHeader, TodolistSection } from '@/app/ui'
+import { mockCategories } from '../mock'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const todolistHeader = {
+  title: 'Example/Todolist/TodolistHeader',
+  component: TodolistHeader,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `투두리스트에 들어가는 TodolistHeader 입니다. 
+        \n\n 해당 투두리스트의 카테고리 제목을 상단에서 보여줍니다.
+        \n\n 우측 상단 상자 버튼을 누르면 Storage page로 이동합니다.
+        \n\n 우측 상단 X 버튼을 누르면 Category page로 이동합니다.`
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    category: mockCategories[0]
+  },
+  decorators: (Story) => (
+    <Container>
+      <TodolistSection>
+        <Story />
+      </TodolistSection>
+    </Container>
+  )
+} satisfies Meta<typeof TodolistHeader>
+
+export default todolistHeader
+type Story = StoryObj<typeof todolistHeader>
+
+/**
+ * 가장 기본적인 형태의 TodolistHeader 입니다.
+ */
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  args: {}
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}


### PR DESCRIPTION
This pull request includes the addition of a new Storybook configuration for the `TodolistHeader` component in the `client/app/stories/todolist/TodolistHeader.stories.tsx` file. The changes include setting up the component's metadata, defining default arguments, and creating different viewport configurations for testing.

Storybook configuration for `TodolistHeader`:

* Added metadata and default arguments for the `TodolistHeader` component, including layout, documentation, and category.
* Created three different viewport configurations (`Styles1Tablet`, `Styles2Desktop`, `Styles3Mobile`) to test the component on tablet, desktop, and mobile devices respectively.