### PR TITLE
Update import paths in story files and fix wrong name in Todoitem, TodolistSecition

### DIFF
--- a/client/app/stories/mock/index.ts
+++ b/client/app/stories/mock/index.ts
@@ -1,1 +1,2 @@
 export * from './category'
+export * from './todolist'

--- a/client/app/stories/todolist/DraggableTodolist.stories.tsx
+++ b/client/app/stories/todolist/DraggableTodolist.stories.tsx
@@ -1,5 +1,5 @@
 import { Container, DraggableTodolist, TodolistSection } from '@/app/ui'
-import { mockTodoItems } from '../mock/todolist'
+import { mockTodoItems } from '@/app/stories/mock'
 import { fn } from '@storybook/test'
 import type { Meta, StoryObj } from '@storybook/react'
 

--- a/client/app/stories/todolist/TodoItem.stories.tsx
+++ b/client/app/stories/todolist/TodoItem.stories.tsx
@@ -1,9 +1,9 @@
 import { Container, TodoItem, TodolistSection } from '@/app/ui'
-import { mockTodoItems } from '../mock/todolist'
+import { mockTodoItems } from '@/app/stories/mock'
 import { fn } from '@storybook/test'
 import type { Meta, StoryObj } from '@storybook/react'
 
-const todolistMain = {
+const todoItem = {
   title: 'Example/Todolist/TodoItem',
   component: TodoItem,
   parameters: {
@@ -30,8 +30,8 @@ const todolistMain = {
   )
 } satisfies Meta<typeof TodoItem>
 
-export default todolistMain
-type Story = StoryObj<typeof todolistMain>
+export default todoItem
+type Story = StoryObj<typeof todoItem>
 
 /**
  * 가장 기본적인 형태의 TodoItem 입니다.

--- a/client/app/stories/todolist/TodolistHeader.stories.tsx
+++ b/client/app/stories/todolist/TodolistHeader.stories.tsx
@@ -1,5 +1,5 @@
 import { Container, TodolistHeader, TodolistSection } from '@/app/ui'
-import { mockCategories } from '../mock'
+import { mockCategories } from '@/app/stories/mock'
 import type { Meta, StoryObj } from '@storybook/react'
 
 const todolistHeader = {

--- a/client/app/stories/todolist/TodolistSection.stories.tsx
+++ b/client/app/stories/todolist/TodolistSection.stories.tsx
@@ -1,7 +1,7 @@
 import { Container, TodolistSection } from '@/app/ui'
 import type { Meta, StoryObj } from '@storybook/react'
 
-const todolistMain = {
+const todolistSection = {
   title: 'Example/Todolist/TodolistSection',
   component: TodolistSection,
   parameters: {
@@ -23,11 +23,11 @@ const todolistMain = {
   )
 } satisfies Meta<typeof TodolistSection>
 
-export default todolistMain
-type Story = StoryObj<typeof todolistMain>
+export default todolistSection
+type Story = StoryObj<typeof todolistSection>
 
 /**
- * 가장 기본적인 형태의 todolistMain 입니다.
+ * 가장 기본적인 형태의 todolistSection 입니다.
  */
 export const Styles1Tablet: Story = {
   parameters: {

--- a/client/app/stories/todolist/usecases/TodolistPage.stories.tsx
+++ b/client/app/stories/todolist/usecases/TodolistPage.stories.tsx
@@ -1,7 +1,6 @@
 import { Container, TodolistDisplay, TodolistHeader, TodolistSection } from '@/app/ui'
 import { fn } from '@storybook/test'
-import { mockCategories } from '../../mock'
-import { mockTodoItems } from '../../mock/todolist'
+import { mockCategories, mockTodoItems } from '@/app/stories/mock'
 import type { Meta, StoryObj } from '@storybook/react'
 
 const TodolistPage = {


### PR DESCRIPTION
This pull request includes several changes to the import paths and variable names in the `client/app/stories/todolist` directory to improve code organization and consistency. The most important changes include updating import paths to use absolute paths and renaming variables for clarity.

### Import Path Updates:

* [`client/app/stories/mock/index.ts`](diffhunk://#diff-af664c60c27d768c5cf7eb0bd3a9ed5978e3e501ddc7b922c5cef57ca1461316R2): Added export for `todolist` to centralize mock data exports.
* [`client/app/stories/todolist/DraggableTodolist.stories.tsx`](diffhunk://#diff-72e354df29560408ea88a8d85948ef226b07b4a62666cd435592e1c8367f857dL2-R2): Updated import path for `mockTodoItems` to use absolute path.
* [`client/app/stories/todolist/TodoItem.stories.tsx`](diffhunk://#diff-87ae5c88bee5a3aba02e5d5b2c68e6abdb08c24881b6466b914c1049b65cf362L2-R6): Updated import path for `mockTodoItems` to use absolute path.
* [`client/app/stories/todolist/TodolistHeader.stories.tsx`](diffhunk://#diff-c9335d4d67ea2840f0a32edcbadd84e9f33efc14061d36456c482c28fbe4aa28L2-R2): Updated import path for `mockCategories` to use absolute path.
* [`client/app/stories/todolist/usecases/TodolistPage.stories.tsx`](diffhunk://#diff-8609cb70a28cd2983e1eb50be9ca48744841d7275fc565c334c31f8be2aa311cL3-R3): Consolidated import paths for `mockCategories` and `mockTodoItems` to use absolute paths.

### Variable Renaming:

* [`client/app/stories/todolist/TodoItem.stories.tsx`](diffhunk://#diff-87ae5c88bee5a3aba02e5d5b2c68e6abdb08c24881b6466b914c1049b65cf362L33-R34): Renamed `todolistMain` to `todoItem` for clarity and updated corresponding export and type definitions.
* [`client/app/stories/todolist/TodolistSection.stories.tsx`](diffhunk://#diff-978ece62d180e677dd51f69f472fce2cc71c0b433262f27b4a13db643ffec210L26-R30): Renamed `todolistMain` to `todolistSection` for clarity and updated corresponding export and type definitions.