### PR TITLE
Add StorageList.stories.tsx

### DIFF
--- a/client/app/stories/mock/todolist.ts
+++ b/client/app/stories/mock/todolist.ts
@@ -1,4 +1,4 @@
-import { Todo } from '@/app/types'
+import { Todo, TodolistsBySortedDates } from '@/app/types'
 
 export const mockTodoItems: Todo[] = [
   {
@@ -27,5 +27,37 @@ export const mockTodoItems: Todo[] = [
     createdAt: new Date(),
     updatedAt: new Date(),
     order: 2
+  }
+]
+
+const otherDateMockTodoitems: Todo[] = [
+  {
+    id: '4',
+    categoryId: '2',
+    title: 'Test todo item title -1',
+    checked: false,
+    createdAt: new Date(new Date().getTime() - 24 * 60 * 60 * 1000),
+    updatedAt: new Date(new Date().getTime() - 24 * 60 * 60 * 1000),
+    order: 3
+  },
+  {
+    id: '5',
+    categoryId: '2',
+    title: 'Test todo item title -2',
+    checked: false,
+    createdAt: new Date(new Date().getTime() - 24 * 60 * 60 * 1000),
+    updatedAt: new Date(new Date().getTime() - 24 * 60 * 60 * 1000),
+    order: 4
+  }
+]
+
+export const mockStorageTodoLists: TodolistsBySortedDates = [
+  {
+    date: new Date().toLocaleString('ko').split('. ').slice(0, 3).join('. '),
+    todolists: mockTodoItems
+  },
+  {
+    date: new Date(new Date().getTime() - 24 * 60 * 60 * 1000).toLocaleString('ko').split('. ').slice(0, 3).join('. '),
+    todolists: otherDateMockTodoitems
   }
 ]

--- a/client/app/stories/storage/StorageList.stories.tsx
+++ b/client/app/stories/storage/StorageList.stories.tsx
@@ -1,0 +1,63 @@
+import { Container, StorageListDisplay, TodolistSection } from '@/app/ui'
+import { mockStorageTodoLists } from '@/app/stories/mock'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const storageList = {
+  title: 'Example/Storage/StorageList',
+  component: StorageListDisplay,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'StorageList에 해당하는 컴포넌트입니다. \n\n 완료된 투두리스트들 중 날짜별로 데이터를 구분해서 보여주는 기능입니다.'
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    list: mockStorageTodoLists
+  },
+  decorators: (Story) => (
+    <Container>
+      <TodolistSection>
+        <Story />
+      </TodolistSection>
+    </Container>
+  )
+} satisfies Meta<typeof StorageListDisplay>
+
+export default storageList
+type Story = StoryObj<typeof storageList>
+
+/**
+ * 가장 기본적인 형태의 storageList 입니다.
+ */
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  args: {}
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}


### PR DESCRIPTION
This pull request includes updates to the mock data and storybook configuration for the `StorageList` component. The changes primarily involve adding new mock data and setting up storybook stories to display the `StorageList` component with different viewports.

Mock data updates:

* [`client/app/stories/mock/todolist.ts`](diffhunk://#diff-fd62e508bff2539b994e352c0e135a4db7a4e6aa4ee487cfecd8d24331da20f1L1-R1): Added new mock todo items and created a new export `mockStorageTodoLists` to organize todo lists by sorted dates. [[1]](diffhunk://#diff-fd62e508bff2539b994e352c0e135a4db7a4e6aa4ee487cfecd8d24331da20f1L1-R1) [[2]](diffhunk://#diff-fd62e508bff2539b994e352c0e135a4db7a4e6aa4ee487cfecd8d24331da20f1R32-R63)

Storybook configuration:

* [`client/app/stories/storage/StorageList.stories.tsx`](diffhunk://#diff-c15628bf83b4de4a31cc3ad03ef5c042fae401c7edc016a1250885133ed2ba03R1-R63): Added storybook configuration for the `StorageList` component, including different viewports for tablet, desktop, and mobile.