### PR TITLE
Add StoragePage component and StorageHeader stories

### DIFF
--- a/client/app/stories/storage/StorageHeader.stories.tsx
+++ b/client/app/stories/storage/StorageHeader.stories.tsx
@@ -1,0 +1,63 @@
+import { Container, StorageHeader, TodolistSection } from '@/app/ui'
+import { mockCategories } from '@/app/stories/mock'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const storageHeader = {
+  title: 'Example/Storage/StorageHeader',
+  component: StorageHeader,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'StorageHeader에 해당하는 컴포넌트입니다. \n\n 우측 상단의 X 버튼을 누르면 이전 투두리스트 화면으로 넘어갑니다.'
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    category: mockCategories[0]
+  },
+  decorators: (Story) => (
+    <Container>
+      <TodolistSection>
+        <Story />
+      </TodolistSection>
+    </Container>
+  )
+} satisfies Meta<typeof StorageHeader>
+
+export default storageHeader
+type Story = StoryObj<typeof storageHeader>
+
+/**
+ * 가장 기본적인 형태의 storageHeader 입니다.
+ */
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  args: {}
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}

--- a/client/app/stories/storage/StorageHeader.stories.tsx
+++ b/client/app/stories/storage/StorageHeader.stories.tsx
@@ -1,4 +1,4 @@
-import { Container, StorageHeader, TodolistSection } from '@/app/ui'
+import { Container, StorageHeader, StorageSection } from '@/app/ui'
 import { mockCategories } from '@/app/stories/mock'
 import type { Meta, StoryObj } from '@storybook/react'
 
@@ -19,9 +19,9 @@ const storageHeader = {
   },
   decorators: (Story) => (
     <Container>
-      <TodolistSection>
+      <StorageSection>
         <Story />
-      </TodolistSection>
+      </StorageSection>
     </Container>
   )
 } satisfies Meta<typeof StorageHeader>

--- a/client/app/stories/storage/StorageList.stories.tsx
+++ b/client/app/stories/storage/StorageList.stories.tsx
@@ -1,4 +1,4 @@
-import { Container, StorageListDisplay, TodolistSection } from '@/app/ui'
+import { Container, StorageListDisplay, StorageSection } from '@/app/ui'
 import { mockStorageTodoLists } from '@/app/stories/mock'
 import type { Meta, StoryObj } from '@storybook/react'
 
@@ -19,9 +19,9 @@ const storageList = {
   },
   decorators: (Story) => (
     <Container>
-      <TodolistSection>
+      <StorageSection>
         <Story />
-      </TodolistSection>
+      </StorageSection>
     </Container>
   )
 } satisfies Meta<typeof StorageListDisplay>

--- a/client/app/stories/storage/usecases/StoragePage.stories.tsx
+++ b/client/app/stories/storage/usecases/StoragePage.stories.tsx
@@ -1,0 +1,51 @@
+import { Container, StorageHeader, StorageListDisplay, StorageSection } from '@/app/ui'
+import { mockCategories, mockStorageTodoLists } from '@/app/stories/mock'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const StoragePage = {
+  title: 'Example/Storage/UseCase/Page',
+  component: StorageListDisplay,
+  parameters: {
+    layout: 'fullscreen',
+    tags: ['!autodocs']
+  },
+  argTypes: {},
+  args: {
+    list: mockStorageTodoLists
+  },
+  decorators: (Story) => (
+    <Container>
+      <StorageSection>
+        <StorageHeader category={mockCategories[0]} />
+        <Story />
+      </StorageSection>
+    </Container>
+  )
+} satisfies Meta<typeof StorageListDisplay>
+
+export default StoragePage
+type Story = StoryObj<typeof StoragePage>
+
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  }
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  }
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  }
+}


### PR DESCRIPTION
This pull request includes several updates to the storybook files for the storage components in the client application. The changes primarily involve adding new stories for `StorageHeader`, updating existing stories to use the correct component, and creating a new use case story for the storage page.

### New Stories and Updates:

* [`client/app/stories/storage/StorageHeader.stories.tsx`](diffhunk://#diff-9a6ae7d39b6c32efba49cb2aad3c296e013e12d76d5fe01ae9aa591424b2b2d5R1-R63): Added a new story for `StorageHeader` with different viewport styles for tablet, desktop, and mobile.
* [`client/app/stories/storage/StorageList.stories.tsx`](diffhunk://#diff-c15628bf83b4de4a31cc3ad03ef5c042fae401c7edc016a1250885133ed2ba03L1-R1): Updated to use `StorageSection` instead of `TodolistSection` for consistency. [[1]](diffhunk://#diff-c15628bf83b4de4a31cc3ad03ef5c042fae401c7edc016a1250885133ed2ba03L1-R1) [[2]](diffhunk://#diff-c15628bf83b4de4a31cc3ad03ef5c042fae401c7edc016a1250885133ed2ba03L22-R24)
* [`client/app/stories/storage/usecases/StoragePage.stories.tsx`](diffhunk://#diff-32dd69501865ebdc7c3ab2e2b0db69292788d6cf0303abbe87579f3c395c286cR1-R51): Created a new story for the storage page use case, including different viewport styles and a decorator to wrap the story in `StorageHeader` and `StorageSection` components.