### PR TITLE
Refactor styles.ts: Update enum types to type aliases

### DIFF
--- a/client/app/types/styles.ts
+++ b/client/app/types/styles.ts
@@ -1,26 +1,14 @@
 /** Common **/
 
-export enum borderRadius {
-  SMALL = 'small',
-  MEDIUM = 'medium',
-  LARGE = 'large'
-}
+export type borderRadius = 'small' | 'medium' | 'large'
 
-export enum boxShadow {
-  PRIMARY = 'primary'
-}
+export type boxShadow = 'primary'
 
 export type commonComponents = 'section' | 'title'
 
-/** Todolist **/
-
-export type todolistHeights = 'HEADER' | 'CREATE_INPUT'
-
-/** Category **/
-
 export enum mediaQueryStandard {
-  MOBILE = '37.5rem',
   TABLET = '45rem',
+  MOBILE = '37.5rem',
   DESKTOP = '90.125rem'
 }
 
@@ -29,6 +17,12 @@ export enum sectionWidth {
   MOBILE = '20rem',
   DESKTOP = '75rem'
 }
+
+/** Todolist **/
+
+export type todolistHeights = 'HEADER' | 'CREATE_INPUT'
+
+/** Category **/
 
 export type categoryComponents = 'title' | 'time'
 

--- a/client/app/types/styles.ts
+++ b/client/app/types/styles.ts
@@ -1,3 +1,11 @@
+/** Todolist **/
+
+export type todolistHeights = 'HEADER' | 'CREATE_INPUT'
+
+/** Category **/
+
+export type categoryComponents = 'title' | 'time'
+
 /** Common **/
 
 export type borderRadius = 'small' | 'medium' | 'large'
@@ -18,28 +26,14 @@ export enum sectionWidth {
   DESKTOP = '75rem'
 }
 
-/** Todolist **/
-
-export type todolistHeights = 'HEADER' | 'CREATE_INPUT'
-
-/** Category **/
-
-export type categoryComponents = 'title' | 'time'
-
-/** Button **/
-
 export interface buttonStyleProps {
   stylestheme: buttonsTheme
   size: buttonSize
 }
 
 export enum buttonsTheme {
-  BRIGHT = 'BRIGHT',
-  DARK = 'DARK'
+  BRIGHT = 'bright',
+  DARK = 'dark'
 }
 
-export enum buttonSize {
-  SMALL = 'small',
-  MEDIUM = 'medium',
-  LARGE = 'large'
-}
+export type buttonSize = 'small' | 'medium' | 'large'


### PR DESCRIPTION
This pull request includes changes to the `client/app/types/styles.ts` file, focusing on refactoring that enum to union type #125 

Refactoring and renaming type definitions:

* Renamed `borderRadius` and `boxShadow` enums to type definitions and moved them under the `Common` section.
* Renamed `categoryComponents` type and moved it under the `Category` section.
* Renamed `buttonsTheme` and `buttonSize` enums to type definitions and updated their values to lowercase.

Reorganization of sections:

* Moved `todolistHeights` type definition from the `Common` section to the `Todolist` section.
* Reorganized the order of sections to maintain a logical grouping of related type definitions.