### PR TITLE
Update TODOLIST_HEIGHTS constants to use camelCase

### DIFF
--- a/client/app/styles/styles.ts
+++ b/client/app/styles/styles.ts
@@ -22,8 +22,8 @@ export const BOX_SHADOWS: Record<boxShadow, RuleSet> = {
 }
 
 export const TODOLIST_HEIGHTS: Record<todolistHeights, string> = {
-  HEADER: '4.21875rem',
-  CREATE_INPUT: '2.5rem'
+  header: '4.21875rem',
+  createInput: '2.5rem'
 }
 
 export const SCROLL_BAR_SETTINGS = css`

--- a/client/app/types/styles.ts
+++ b/client/app/types/styles.ts
@@ -1,6 +1,6 @@
 /** Todolist **/
 
-export type todolistHeights = 'HEADER' | 'CREATE_INPUT'
+export type todolistHeights = 'header' | 'createInput'
 
 /** Category **/
 

--- a/client/app/ui/storage/StorageHeader.tsx
+++ b/client/app/ui/storage/StorageHeader.tsx
@@ -7,7 +7,7 @@ import { TODOLIST_HEIGHTS, COLORS } from '@/app/styles'
 import { IoClose } from 'react-icons/io5'
 
 const Header = styled.div`
-  height: ${TODOLIST_HEIGHTS.HEADER};
+  height: ${TODOLIST_HEIGHTS.header};
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/client/app/ui/todolist/CreateTodolist.tsx
+++ b/client/app/ui/todolist/CreateTodolist.tsx
@@ -8,8 +8,8 @@ const CreateTodolistWrapper = styled.div`
   position: absolute;
   bottom: 0;
   width: 100%;
-  height: ${TODOLIST_HEIGHTS.CREATE_INPUT};
-  min-height: ${TODOLIST_HEIGHTS.CREATE_INPUT};
+  height: ${TODOLIST_HEIGHTS.createInput};
+  min-height: ${TODOLIST_HEIGHTS.createInput};
   display: flex;
   justify-content: space-between;
   border-top: 1px solid ${COLORS.GRAY_200};

--- a/client/app/ui/todolist/TodolistDisplay.tsx
+++ b/client/app/ui/todolist/TodolistDisplay.tsx
@@ -6,7 +6,7 @@ import { CreateTodolist, DraggableTodolist, TodoUpdateModal } from '@/app/ui'
 import { useTodolist, useTodolistEditModal } from '@/app/utils'
 
 const TodolistWrapper = styled.div`
-  height: calc(100% - (${TODOLIST_HEIGHTS.HEADER} + ${TODOLIST_HEIGHTS.CREATE_INPUT}));
+  height: calc(100% - (${TODOLIST_HEIGHTS.header} + ${TODOLIST_HEIGHTS.createInput}));
   ${SCROLL_BAR_SETTINGS};
 `
 

--- a/client/app/ui/todolist/TodolistHeader.tsx
+++ b/client/app/ui/todolist/TodolistHeader.tsx
@@ -8,7 +8,7 @@ import { FaBox } from 'react-icons/fa'
 import { IoClose } from 'react-icons/io5'
 
 const Header = styled.div`
-  height: ${TODOLIST_HEIGHTS.HEADER};
+  height: ${TODOLIST_HEIGHTS.header};
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
This pull request includes changes to the `TODOLIST_HEIGHTS` type and its usage across various files to ensure consistency and improve code readability. The most important changes include updating the type definition and modifying the related constants and imports accordingly.

Changes to type definition and constants:

* [`client/app/types/styles.ts`](diffhunk://#diff-ed88be69065ba278d41e0bfce32f30b33caf0a667cc879bf9d2116573fa4141fL3-R3): Updated the `todolistHeights` type to use camelCase instead of uppercase.
* [`client/app/styles/styles.ts`](diffhunk://#diff-97f1e4fab09538352433e5e49bffddbc226e532c66470b46994a1cf61e9813a6L25-R26): Modified the `TODOLIST_HEIGHTS` constants to use camelCase keys.

Updates to component styles:

* [`client/app/ui/storage/StorageHeader.tsx`](diffhunk://#diff-431fa52b0770435aa605883e8bd711fd79422407ef19b9bfe91ae4b149ce9ac9L10-R10): Updated the `TODOLIST_HEIGHTS` usage to reflect the new camelCase keys.
* [`client/app/ui/todolist/CreateTodolist.tsx`](diffhunk://#diff-9b011d4a6541833e0391d260158d2b76b1ebd52668d010fc9eb13fbda8ba0485L11-R12): Modified the `TODOLIST_HEIGHTS` references to use the new camelCase keys.
* [`client/app/ui/todolist/TodolistDisplay.tsx`](diffhunk://#diff-f56a075ff63896419eb1f6134a316fda7c4e3a0fa3fa227e527ce2ba40b91967L9-R9): Changed the `TODOLIST_HEIGHTS` usage in the height calculation to use camelCase keys.
* [`client/app/ui/todolist/TodolistHeader.tsx`](diffhunk://#diff-30c162819729fd9328d8114cb609486f7aadac15a23ca901d13c2ce6563e97faL11-R11): Updated the `TODOLIST_HEIGHTS` usage to reflect the new camelCase keys.