### PR TITLE
Update button style props in button.ts and Button.tsx

### DIFF
--- a/client/app/styles/button.ts
+++ b/client/app/styles/button.ts
@@ -1,9 +1,9 @@
 import { css } from 'styled-components'
 import { RuleSet } from 'styled-components/dist/types'
 import { COLORS } from '@/app/styles'
-import { buttonSize, buttonStyleProps, buttonsTheme } from '@/app/types'
+import { buttonSize, ButtonStyleProps, buttonsTheme } from '@/app/types'
 
-export const BUTTON_DEFAULT_STYLE = css<buttonStyleProps>`
+export const BUTTON_DEFAULT_STYLE = css<ButtonStyleProps>`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/client/app/ui/common/Button.tsx
+++ b/client/app/ui/common/Button.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
 import { BUTTON_SIZES, BUTTON_DEFAULT_STYLE } from '@/app/styles/button'
-import { buttonStyleProps, buttonsTheme, buttonSize } from '@/app/types'
+import { ButtonStyleProps, buttonsTheme, buttonSize } from '@/app/types'
 
-const StyledButton = styled.button<buttonStyleProps>`
+const StyledButton = styled.button<ButtonStyleProps>`
   ${BUTTON_DEFAULT_STYLE};
   ${(props) => {
     return BUTTON_SIZES[props.size]


### PR DESCRIPTION
This pull request includes changes to improve type consistency in the `Button` component styles and props across the codebase. ButtonStyleProps is literally props, so we think it's right to use pascal case in the naming convention.

Type consistency improvements:

* [`client/app/styles/button.ts`](diffhunk://#diff-c203583ba4263bad891466a033a874283f8d1aa313d067fcf0d45ae261c1d5bfL4-R6): Changed the type name from `buttonStyleProps` to `ButtonStyleProps` to maintain consistent casing.
* [`client/app/ui/common/Button.tsx`](diffhunk://#diff-eb114d6939f6fd94aea7b9c5e4d2f2d5cb368171e495965ed01636e1bb2c2a1fL4-R6): Updated the type name from `buttonStyleProps` to `ButtonStyleProps` to match the casing used in the styles file.