### PR TITLE
move usecase stories files to each stories pages

### DIFF
--- a/client/app/stories/category/pages/CategoryPage.stories.tsx
+++ b/client/app/stories/category/pages/CategoryPage.stories.tsx
@@ -3,7 +3,7 @@ import { mockCategories } from '@/app/stories/mock'
 import type { StoryObj } from '@storybook/react'
 
 const categoryPage = {
-  title: 'Example/Category/UseCases/Page',
+  title: 'Example/Category/1. Pages/Pages',
   parameters: {
     layout: 'center'
   },

--- a/client/app/stories/storage/pages/StoragePage.stories.tsx
+++ b/client/app/stories/storage/pages/StoragePage.stories.tsx
@@ -3,7 +3,7 @@ import { mockCategories, mockStorageTodoLists } from '@/app/stories/mock'
 import type { Meta, StoryObj } from '@storybook/react'
 
 const StoragePage = {
-  title: 'Example/Storage/UseCase/Page',
+  title: 'Example/Storage/1. Pages/Pages',
   component: StorageListDisplay,
   parameters: {
     layout: 'fullscreen',

--- a/client/app/stories/todolist/pages/TodolistPage.stories.tsx
+++ b/client/app/stories/todolist/pages/TodolistPage.stories.tsx
@@ -4,7 +4,7 @@ import { mockCategories, mockTodoItems } from '@/app/stories/mock'
 import type { Meta, StoryObj } from '@storybook/react'
 
 const TodolistPage = {
-  title: 'Example/Todolist/UseCase/Page',
+  title: 'Example/Todolist/1. Pages/Pages',
   component: TodolistDisplay,
   parameters: {
     layout: 'fullscreen',


### PR DESCRIPTION
This pull request involves renaming and updating the titles of several Storybook files to improve their organization and clarity. The most important changes include renaming files from the `useCases` directory to the `pages` directory and updating the titles to follow a consistent naming convention.

File renaming and title updates:

* [`client/app/stories/category/pages/CategoryPage.stories.tsx`](diffhunk://#diff-7ca01f181370f5eb28a8fd0488b9bef3a78553e2a6e84d420471c4de5da5a524L6-R6): Renamed from `client/app/stories/category/useCases/CategoryPage.stories.tsx` and updated the title to 'Example/Category/1. Pages/Pages'.
* [`client/app/stories/storage/pages/StoragePage.stories.tsx`](diffhunk://#diff-99f9efb13b394d68d1deb81084bbb0ab0bb680003bad43fb365cc25eae1b77ceL6-R6): Renamed from `client/app/stories/storage/usecases/StoragePage.stories.tsx` and updated the title to 'Example/Storage/1. Pages/Pages'.
* [`client/app/stories/todolist/pages/TodolistPage.stories.tsx`](diffhunk://#diff-27ea3baa20058d0836acab15e6763ce6b14665661e8927fc465b9b54ad088d64L7-R7): Renamed from `client/app/stories/todolist/usecases/TodolistPage.stories.tsx` and updated the title to 'Example/Todolist/1. Pages/Pages'.