### PR TITLE
Refactoring import order in etc files

### DIFF
--- a/client/app/api/category/[categoryId]/route.ts
+++ b/client/app/api/category/[categoryId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { UUID } from '@/app/types'
 import { fetchToBackend } from '@/app/utils'
+import { UUID } from '@/app/types'
 
 interface Params {
   params: {

--- a/client/app/api/todolist/[categoryId]/route.ts
+++ b/client/app/api/todolist/[categoryId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { UUID } from '@/app/types'
 import { fetchToBackend } from '@/app/utils'
+import { UUID } from '@/app/types'
 
 interface Params {
   params: {

--- a/client/app/api/todolist/dates/[categoryId]/route.ts
+++ b/client/app/api/todolist/dates/[categoryId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
-import { UUID } from '@/app/types'
 import { fetchToBackend } from '@/app/utils'
+import { UUID } from '@/app/types'
 
 interface Params {
   params: {

--- a/client/app/api/todolist/order/route.ts
+++ b/client/app/api/todolist/order/route.ts
@@ -1,5 +1,5 @@
-import { fetchToBackend } from '@/app/utils'
 import { NextResponse } from 'next/server'
+import { fetchToBackend } from '@/app/utils'
 
 export async function PATCH(req: Request) {
   const body = await req.json()

--- a/client/app/error.tsx
+++ b/client/app/error.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import styled from 'styled-components'
-import { BORDER_RADIUS_SIZES, BOX_SHADOWS, COLORS, FONT_SIZES } from './styles'
-import { Button, Container } from './ui'
 import { useEffect, useState } from 'react'
-import { InternalError, mediaQueryStandard } from './types'
+import styled from 'styled-components'
+import { Button, Container } from '@/app/ui'
+import { InternalError, mediaQueryStandard } from '@/app/types'
+import { BORDER_RADIUS_SIZES, BOX_SHADOWS, COLORS, FONT_SIZES } from '@/app/styles'
 
 const ErrorSection = styled.section`
   width: ${mediaQueryStandard.TABLET};

--- a/client/app/styles/button.ts
+++ b/client/app/styles/button.ts
@@ -1,7 +1,7 @@
 import { css } from 'styled-components'
 import { RuleSet } from 'styled-components/dist/types'
-import { COLORS } from '@/app/styles'
 import { buttonSize, ButtonStyleProps, buttonsTheme } from '@/app/types'
+import { COLORS } from '@/app/styles'
 
 export const BUTTON_DEFAULT_STYLE = css<ButtonStyleProps>`
   display: flex;


### PR DESCRIPTION
This pull request includes several changes to improve the import statements across various files in the `client/app` directory. The main focus is on reordering imports to ensure consistent and clean code structure.

#131 

Import statement reordering:

* `client/app/api/category/[categoryId]/route.ts`: Reordered the import of `UUID` from `@/app/types` to follow the import of `fetchToBackend` from `@/app/utils`. ([client/app/api/category/[categoryId]/route.tsL2-R3](diffhunk://#diff-7a31425dafa44a7559333773e755c30d2de050ac01e9f1bd80bd7b2a98dd43d3L2-R3))
* `client/app/api/todolist/[categoryId]/route.ts`: Reordered the import of `UUID` from `@/app/types` to follow the import of `fetchToBackend` from `@/app/utils`. ([client/app/api/todolist/[categoryId]/route.tsL2-R3](diffhunk://#diff-737b0ab0a6d4abfa2ee62fc54a52ce4ae12a765fa727ba6af67793e147b9c0e3L2-R3))
* `client/app/api/todolist/dates/[categoryId]/route.ts`: Reordered the import of `UUID` from `@/app/types` to follow the import of `fetchToBackend` from `@/app/utils`. ([client/app/api/todolist/dates/[categoryId]/route.tsL2-R3](diffhunk://#diff-57f50709182defaf9174535dfc8ad1fdb561b080f600fad6d0850099b5e3865aL2-R3))
* [`client/app/api/todolist/order/route.ts`](diffhunk://#diff-cdb09f0f5dfa5d5983a54c61ff282bd615dae1702bd62a4af3d445caf337f0d0L1-R2): Moved the import of `fetchToBackend` from `@/app/utils` to follow the import of `NextResponse` from 'next/server'.
* [`client/app/error.tsx`](diffhunk://#diff-e6d8a43843e02917d19cfa69b9649964af959e4986bf21d841113a80139417d7L3-R7): Reordered and updated imports to use absolute paths for consistency, moving `styled-components` and other imports to follow a structured order.
* [`client/app/styles/button.ts`](diffhunk://#diff-c203583ba4263bad891466a033a874283f8d1aa313d067fcf0d45ae261c1d5bfL3-R4): Reordered the import of `COLORS` from `@/app/styles` to follow the import of `buttonSize`, `ButtonStyleProps`, and `buttonsTheme` from `@/app/types`.