### PR TITLE
Update import paths for Category components

### DIFF
--- a/client/app/stories/category/Categories.stories.tsx
+++ b/client/app/stories/category/Categories.stories.tsx
@@ -1,6 +1,7 @@
 import { fn } from '@storybook/test'
 import type { Meta, StoryObj } from '@storybook/react'
-import { Categories, CategorySection, Container } from '@/app/ui'
+import { Container } from '@/app/ui'
+import { Categories, CategorySection } from '@/app/(main)/category/components'
 import { mockCategories } from '@/app/stories/mock'
 
 const categories = {

--- a/client/app/stories/category/CategoryItem.stories.tsx
+++ b/client/app/stories/category/CategoryItem.stories.tsx
@@ -1,7 +1,8 @@
 import { fn } from '@storybook/test'
 import type { Meta, StoryObj } from '@storybook/react'
-import { CategorySection, Container } from '@/app/ui'
-import { CategoryItem } from '@/app/ui/category/CategoryItem'
+import { Container } from '@/app/ui'
+import { CategoryItem } from '@/app/(main)/category/components/CategoryItem'
+import { CategorySection } from '@/app/(main)/category/components'
 
 const categoryItem = {
   title: 'Example/Category/CategoryItem',

--- a/client/app/stories/category/CategorySection.stories.tsx
+++ b/client/app/stories/category/CategorySection.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { CategorySection, Container } from '@/app/ui'
+import { Container } from '@/app/ui'
+import { CategorySection } from '@/app/(main)/category/components'
 
 const categorySection = {
   title: 'Example/Category/CategorySection',

--- a/client/app/stories/category/CreateCategory.stories.tsx
+++ b/client/app/stories/category/CreateCategory.stories.tsx
@@ -1,6 +1,7 @@
 import { fn } from '@storybook/test'
 import type { Meta, StoryObj } from '@storybook/react'
-import { CategorySection, Container, CreateCategory } from '@/app/ui'
+import { Container } from '@/app/ui'
+import { CategorySection, CreateCategory } from '@/app/(main)/category/components'
 
 const createCategory = {
   title: 'Example/Category/CreateCategory',

--- a/client/app/stories/category/pages/CategoryPage.stories.tsx
+++ b/client/app/stories/category/pages/CategoryPage.stories.tsx
@@ -1,5 +1,6 @@
 import type { StoryObj } from '@storybook/react'
-import { CategoryDisplay, CategorySection, Container, CreateCategory, Title } from '@/app/ui'
+import { Container, Title } from '@/app/ui'
+import { CategoryDisplay, CategorySection, CreateCategory } from '@/app/(main)/category/components'
 import { mockCategories } from '@/app/stories/mock'
 
 const categoryPage = {


### PR DESCRIPTION
This pull request focuses on reorganizing the import paths for category-related components in the Storybook stories. The main changes involve updating the import paths to reflect the new directory structure.

Changes to import paths:

* [`client/app/stories/category/Categories.stories.tsx`](diffhunk://#diff-f43dba2f3a952012107fe989763d6a045422f5110d8ff14aeff9ae34b3233ecfL3-R4): Updated import paths for `Categories` and `CategorySection` to the new location in `components`.
* [`client/app/stories/category/CategoryItem.stories.tsx`](diffhunk://#diff-5b7f787df7ce5fcfd46b9231378428d888d01bc6cb82d26301a16ab32a4ec1bbL3-R5): Updated import paths for `CategoryItem` and `CategorySection` to the new location in `components`.
* [`client/app/stories/category/CategorySection.stories.tsx`](diffhunk://#diff-662441ad7c883ff76f18a5bf13f1d77ebfd5702ffd57216d384f36b350258746L2-R3): Updated import path for `CategorySection` to the new location in `components`.
* [`client/app/stories/category/CreateCategory.stories.tsx`](diffhunk://#diff-ae2bc5182876cadf22a470dab3fe1109c3dd2cedffa158c4d803399a41f7a1a3L3-R4): Updated import paths for `CategorySection` and `CreateCategory` to the new location in `components`.
* [`client/app/stories/category/pages/CategoryPage.stories.tsx`](diffhunk://#diff-7ca01f181370f5eb28a8fd0488b9bef3a78553e2a6e84d420471c4de5da5a524L2-R3): Updated import paths for `CategoryDisplay`, `CategorySection`, and `CreateCategory` to the new location in `components`.