### PR TITLE
Update import paths for StorageHeader, StorageList, and StoragePage

### DIFF
--- a/client/app/stories/storage/StorageHeader.stories.tsx
+++ b/client/app/stories/storage/StorageHeader.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Container, StorageHeader, StorageSection } from '@/app/ui'
+import { Container } from '@/app/ui'
+import { StorageHeader, StorageSection } from '@/app/(main)/storage/components'
 import { mockCategories } from '@/app/stories/mock'
 
 const storageHeader = {

--- a/client/app/stories/storage/StorageList.stories.tsx
+++ b/client/app/stories/storage/StorageList.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Container, StorageListDisplay, StorageSection } from '@/app/ui'
+import { Container } from '@/app/ui'
+import { StorageListDisplay, StorageSection } from '@/app/(main)/storage/components'
 import { mockStorageTodoLists } from '@/app/stories/mock'
 
 const storageList = {

--- a/client/app/stories/storage/pages/StoragePage.stories.tsx
+++ b/client/app/stories/storage/pages/StoragePage.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Container, StorageHeader, StorageListDisplay, StorageSection } from '@/app/ui'
+import { Container } from '@/app/ui'
+import { StorageHeader, StorageListDisplay, StorageSection } from '@/app/(main)/storage/components'
 import { mockCategories, mockStorageTodoLists } from '@/app/stories/mock'
 
 const StoragePage = {


### PR DESCRIPTION
This pull request involves updating import paths in several story files to reflect the new organization of components within the `storage` module. The changes ensure that components are imported from their correct locations.

Changes to import paths:

* [`client/app/stories/storage/StorageHeader.stories.tsx`](diffhunk://#diff-9a6ae7d39b6c32efba49cb2aad3c296e013e12d76d5fe01ae9aa591424b2b2d5L2-R3): Updated import paths for `StorageHeader` and `StorageSection` to import from `@/app/(main)/storage/components`.
* [`client/app/stories/storage/StorageList.stories.tsx`](diffhunk://#diff-c15628bf83b4de4a31cc3ad03ef5c042fae401c7edc016a1250885133ed2ba03L2-R3): Updated import paths for `StorageListDisplay` and `StorageSection` to import from `@/app/(main)/storage/components`.
* [`client/app/stories/storage/pages/StoragePage.stories.tsx`](diffhunk://#diff-99f9efb13b394d68d1deb81084bbb0ab0bb680003bad43fb365cc25eae1b77ceL2-R3): Updated import paths for `StorageHeader`, `StorageListDisplay`, and `StorageSection` to import from `@/app/(main)/storage/components`.