### PR TITLE
Update makeUpdatedTodo function to accept a title parameter

### DIFF
--- a/client/app/(main)/todolist/components/TodoUpdateModal.tsx
+++ b/client/app/(main)/todolist/components/TodoUpdateModal.tsx
@@ -14,7 +14,7 @@ const EditModalContents = styled.div`
 
 interface Props {
   placeholder?: string
-  makeUpdatedTodo: () => UpdateTodoDTO | undefined
+  makeUpdatedTodo: (title: string) => UpdateTodoDTO | undefined
   handleEditTodo: (updated: UpdateTodoDTO) => Promise<void>
   handleEditModalClose: () => void
 }
@@ -26,7 +26,7 @@ export function TodoUpdateModal({ placeholder, makeUpdatedTodo, handleEditModalC
     <AgreementModal
       title="Edit"
       handleAgree={() => {
-        const updated = makeUpdatedTodo()
+        const updated = makeUpdatedTodo(updateTitle)
         if (updated) handleEditTodo(updated)
         handleEditModalClose()
       }}

--- a/client/app/(main)/todolist/hooks/useTodolistEditModal.ts
+++ b/client/app/(main)/todolist/hooks/useTodolistEditModal.ts
@@ -4,14 +4,13 @@ import { Todo, UpdateTodoDTO } from '@/app/types'
 export function useTodolistEditModal() {
   const [modal, setModal] = useState<'edit'>()
   const [targetTodo, setTargetTodo] = useState<Todo>()
-  const [updateTitle, setUpdateTitle] = useState('')
 
-  const makeUpdatedTodo = () => {
+  const makeUpdatedTodo = (title: string) => {
     if (!targetTodo) return
 
     const updated: UpdateTodoDTO = {
       id: targetTodo.id,
-      title: updateTitle,
+      title,
       checked: targetTodo.checked
     }
 
@@ -26,14 +25,11 @@ export function useTodolistEditModal() {
   const handleEditModalClose = () => {
     setModal(undefined)
     setTargetTodo(undefined)
-    setUpdateTitle('')
   }
 
   return {
     modal,
     targetTodo,
-    updateTitle,
-    setUpdateTitle,
     makeUpdatedTodo,
     handleEditModalOpen,
     handleEditModalClose


### PR DESCRIPTION
This pull request includes changes to the `TodoUpdateModal` and `useTodolistEditModal` components to improve the handling of the `updateTitle` state. The most important changes include modifying the `makeUpdatedTodo` function to take a `title` parameter and updating the `TodoUpdateModal` component to pass the `updateTitle` to this function.

Changes to `TodoUpdateModal`:

* Modified the `makeUpdatedTodo` function to take a `title` parameter instead of using the `updateTitle` state directly. (`client/app/(main)/todolist/components/TodoUpdateModal.tsx`)
* Updated the `handleAgree` function to pass the `updateTitle` to the `makeUpdatedTodo` function. (`client/app/(main)/todolist/components/TodoUpdateModal.tsx`)

Changes to `useTodolistEditModal`:

* Modified the `makeUpdatedTodo` function to take a `title` parameter and use it instead of the `updateTitle` state. (`client/app/(main)/todolist/hooks/useTodolistEditModal.ts`)
* Removed the `updateTitle` state and its setter from the `useTodolistEditModal` hook. (`client/app/(main)/todolist/hooks/useTodolistEditModal.ts`)