### PR TITLE
Add TODOLIST_MEDIA_QUERY to CreateTodolist component

### DIFF
--- a/client/app/(main)/todolist/components/CreateTodolist.tsx
+++ b/client/app/(main)/todolist/components/CreateTodolist.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Button, Input } from '@/app/components'
-import { TODOLIST_HEIGHTS, COLORS } from '@/app/styles'
+import { TODOLIST_HEIGHTS, COLORS, TODOLIST_MEDIA_QUERY } from '@/app/styles'
 
 const CreateTodolistWrapper = styled.div`
   position: absolute;
@@ -12,10 +12,9 @@ const CreateTodolistWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   border-top: 1px solid ${COLORS.GRAY_200};
-  border-bottom-right-radius: 0.5rem;
-  border-bottom-left-radius: 0.5rem;
   overflow: hidden;
   z-index: 100;
+  ${TODOLIST_MEDIA_QUERY.createButtonWrapper}
 `
 
 interface Props {

--- a/client/app/styles/mediaQueries.ts
+++ b/client/app/styles/mediaQueries.ts
@@ -1,5 +1,5 @@
 import { RuleSet, css } from 'styled-components'
-import { categoryComponents, commonComponents, mediaQueryStandard, sectionWidth } from '@/app/types'
+import { categoryComponents, commonComponents, mediaQueryStandard, sectionWidth, todolistComponents } from '@/app/types'
 import { FONT_SIZES } from '@/app/styles'
 
 export const COMMON_MEDIA_QUERY: Record<commonComponents, RuleSet> = {
@@ -52,6 +52,17 @@ export const CATEGORY_MEDIA_QUERY: Record<categoryComponents, RuleSet> = {
 
     @media only screen and (min-width: ${mediaQueryStandard.DESKTOP}) {
       font-size: ${FONT_SIZES.sm};
+    }
+  `
+}
+
+export const TODOLIST_MEDIA_QUERY: Record<todolistComponents, RuleSet> = {
+  createButtonWrapper: css`
+    border-bottom-right-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+
+    @media only screen and (max-width: ${mediaQueryStandard.MOBILE}) {
+      border-radius: 0rem;
     }
   `
 }

--- a/client/app/types/styles.ts
+++ b/client/app/types/styles.ts
@@ -2,6 +2,8 @@
 
 export type todolistHeights = 'header' | 'createInput'
 
+export type todolistComponents = 'createButtonWrapper'
+
 /** Category **/
 
 export type categoryComponents = 'title' | 'time'


### PR DESCRIPTION
This pull request includes changes to the `CreateTodolist` component and the media queries used in the app. The main goal is to introduce a new media query for the `CreateTodolist` component and refactor the existing styles to use this new media query.

Changes to `CreateTodolist` component:

* [`client/app/(main)/todolist/components/CreateTodolist.tsx`](diffhunk://#diff-c2612bbb3c66df2b39a9e36dbd33bcde953d89a61d936b13b5d47d8e2354d929L4-R4): Imported `TODOLIST_MEDIA_QUERY` from `styles` and applied the new media query to the `CreateTodolistWrapper` styled component. [[1]](diffhunk://#diff-c2612bbb3c66df2b39a9e36dbd33bcde953d89a61d936b13b5d47d8e2354d929L4-R4) [[2]](diffhunk://#diff-c2612bbb3c66df2b39a9e36dbd33bcde953d89a61d936b13b5d47d8e2354d929L15-R17)

Changes to media queries:

* [`client/app/styles/mediaQueries.ts`](diffhunk://#diff-ebc01d5dce72de2a819dce453e8f30f0a8fc78416106562c705cd455440eb249L2-R2): Added a new `TODOLIST_MEDIA_QUERY` object with a `createButtonWrapper` rule set, which includes styles for different screen sizes. [[1]](diffhunk://#diff-ebc01d5dce72de2a819dce453e8f30f0a8fc78416106562c705cd455440eb249L2-R2) [[2]](diffhunk://#diff-ebc01d5dce72de2a819dce453e8f30f0a8fc78416106562c705cd455440eb249R58-R68)

Changes to type definitions:

* [`client/app/types/styles.ts`](diffhunk://#diff-ed88be69065ba278d41e0bfce32f30b33caf0a667cc879bf9d2116573fa4141fR5-R6): Added a new `todolistComponents` type to define the components that can use the new media query.