### PR TITLE
Update AgreementModal component to handle refuse action

### DIFF
--- a/client/app/components/AgreementModal.tsx
+++ b/client/app/components/AgreementModal.tsx
@@ -92,8 +92,8 @@ interface Props {
 
 export function AgreementModal({ title, children, handleAgree, handleRefuse }: Props) {
   return (
-    <ModalContainer>
-      <ModalWrapper>
+    <ModalContainer onClick={handleRefuse}>
+      <ModalWrapper onClick={(e) => e.stopPropagation()}>
         <ModalHeader>
           <ModalTitle>{title}</ModalTitle>
           <ModalCloseIcon onClick={handleRefuse}>


### PR DESCRIPTION
This pull request includes a change to the `AgreementModal` component in `client/app/components/AgreementModal.tsx`. The change modifies the click handling behavior to ensure that clicking outside the modal triggers the `handleRefuse` function, while clicking inside the modal does not propagate the click event.

#121 

Changes to click handling behavior:

* [`client/app/components/AgreementModal.tsx`](diffhunk://#diff-19500f4036cab8f2f2f4ab03a5bd1cee3c02cd1e0355166c6abefe14c0307b69L95-R96): Updated `ModalContainer` to call `handleRefuse` on click and added an `onClick` event to `ModalWrapper` to stop propagation.