### PR TITLE
Refactor color constants and add utility functions

### DIFF
--- a/client/app/styles/colors.ts
+++ b/client/app/styles/colors.ts
@@ -1,4 +1,24 @@
-export const COLORS = {
+export type HexColor = `#${string}`
+
+export type ColorGroup = 'RED' | 'GRAY' | 'CLOUD_BLUE'
+export type ColorShade = '100' | '200' | '300' | '400' | '500' | '600'
+export type BasicColor = 'WHITE' | 'BLACK'
+
+export type Colors = {
+  [K in `${ColorGroup}_${ColorShade}`]: HexColor
+} & {
+  [K in BasicColor]: HexColor
+}
+
+type ColorsByGroup<T extends ColorGroup> = {
+  [K in `${T}_${ColorShade}`]: HexColor
+}
+
+type BasicColors = {
+  [K in BasicColor]: HexColor
+}
+
+export const COLORS: Colors = {
   RED_100: '#fcc7c5',
   RED_200: '#e89b99',
   RED_300: '#e67775',
@@ -22,4 +42,54 @@ export const COLORS = {
 
   WHITE: '#ffffff',
   BLACK: '#0d0d0d'
+}
+
+export const getColorsByGroup = {
+  getReds: (): ColorsByGroup<'RED'> => {
+    return Object.entries(COLORS)
+      .filter(([key]) => key.startsWith('RED_'))
+      .reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [key]: value
+        }),
+        {} as ColorsByGroup<'RED'>
+      )
+  },
+
+  getGrays: (): ColorsByGroup<'GRAY'> => {
+    return Object.entries(COLORS)
+      .filter(([key]) => key.startsWith('GRAY_'))
+      .reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [key]: value
+        }),
+        {} as ColorsByGroup<'GRAY'>
+      )
+  },
+
+  getCloudBlues: (): ColorsByGroup<'CLOUD_BLUE'> => {
+    return Object.entries(COLORS)
+      .filter(([key]) => key.startsWith('CLOUD_BLUE_'))
+      .reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [key]: value
+        }),
+        {} as ColorsByGroup<'CLOUD_BLUE'>
+      )
+  },
+
+  getBasicColors: (): BasicColors => {
+    return Object.entries(COLORS)
+      .filter(([key]) => !key.includes('_'))
+      .reduce(
+        (acc, [key, value]) => ({
+          ...acc,
+          [key]: value
+        }),
+        {} as BasicColors
+      )
+  }
 }


### PR DESCRIPTION
This pull request includes significant updates to the `client/app/styles/colors.ts` file, enhancing the type safety and organization of color constants. The changes introduce new TypeScript types for color groups and shades, and add utility functions to retrieve colors by their groups.

Enhancements to type safety and organization:

* Defined new TypeScript types: `HexColor`, `ColorGroup`, `ColorShade`, `BasicColor`, and `Colors` to improve type safety and clarity in color definitions.
* Added `ColorsByGroup` and `BasicColors` types to facilitate grouped color retrieval.

Utility functions for color retrieval:

* Introduced `getColorsByGroup` object with methods `getReds`, `getGrays`, `getCloudBlues`, and `getBasicColors` to retrieve colors by their respective groups.