### PR TITLE
Refactor color-related code and add color utility function

### DIFF
--- a/client/app/styles/colors.ts
+++ b/client/app/styles/colors.ts
@@ -1,22 +1,4 @@
-export type HexColor = `#${string}`
-
-export type ColorGroup = 'RED' | 'GRAY' | 'CLOUD_BLUE'
-export type ColorShade = '100' | '200' | '300' | '400' | '500' | '600'
-export type BasicColor = 'WHITE' | 'BLACK'
-
-export type Colors = {
-  [K in `${ColorGroup}_${ColorShade}`]: HexColor
-} & {
-  [K in BasicColor]: HexColor
-}
-
-type ColorsByGroup<T extends ColorGroup> = {
-  [K in `${T}_${ColorShade}`]: HexColor
-}
-
-type BasicColors = {
-  [K in BasicColor]: HexColor
-}
+import { Colors } from '@/app/types'
 
 export const COLORS: Colors = {
   RED_100: '#fcc7c5',
@@ -42,54 +24,4 @@ export const COLORS: Colors = {
 
   WHITE: '#ffffff',
   BLACK: '#0d0d0d'
-}
-
-export const getColorsByGroup = {
-  getReds: (): ColorsByGroup<'RED'> => {
-    return Object.entries(COLORS)
-      .filter(([key]) => key.startsWith('RED_'))
-      .reduce(
-        (acc, [key, value]) => ({
-          ...acc,
-          [key]: value
-        }),
-        {} as ColorsByGroup<'RED'>
-      )
-  },
-
-  getGrays: (): ColorsByGroup<'GRAY'> => {
-    return Object.entries(COLORS)
-      .filter(([key]) => key.startsWith('GRAY_'))
-      .reduce(
-        (acc, [key, value]) => ({
-          ...acc,
-          [key]: value
-        }),
-        {} as ColorsByGroup<'GRAY'>
-      )
-  },
-
-  getCloudBlues: (): ColorsByGroup<'CLOUD_BLUE'> => {
-    return Object.entries(COLORS)
-      .filter(([key]) => key.startsWith('CLOUD_BLUE_'))
-      .reduce(
-        (acc, [key, value]) => ({
-          ...acc,
-          [key]: value
-        }),
-        {} as ColorsByGroup<'CLOUD_BLUE'>
-      )
-  },
-
-  getBasicColors: (): BasicColors => {
-    return Object.entries(COLORS)
-      .filter(([key]) => !key.includes('_'))
-      .reduce(
-        (acc, [key, value]) => ({
-          ...acc,
-          [key]: value
-        }),
-        {} as BasicColors
-      )
-  }
 }

--- a/client/app/types/styles.ts
+++ b/client/app/types/styles.ts
@@ -41,3 +41,24 @@ export enum buttonsTheme {
 export type buttonSize = 'small' | 'medium' | 'large'
 
 export type fontSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+/** Colors */
+
+export type HexColor = `#${string}`
+export type ColorGroup = 'RED' | 'GRAY' | 'CLOUD_BLUE'
+export type ColorShade = '100' | '200' | '300' | '400' | '500' | '600'
+export type BasicColor = 'WHITE' | 'BLACK'
+
+export type Colors = {
+  [K in `${ColorGroup}_${ColorShade}`]: HexColor
+} & {
+  [K in BasicColor]: HexColor
+}
+
+export type ColorsByGroup<T extends ColorGroup> = {
+  [K in `${T}_${ColorShade}`]: HexColor
+}
+
+export type BasicColors = {
+  [K in BasicColor]: HexColor
+}

--- a/client/app/utils/common.ts
+++ b/client/app/utils/common.ts
@@ -1,5 +1,8 @@
 /** MouseEvent */
 
+import { ColorsByGroup, ColorGroup } from '@/app/types'
+import { COLORS } from '@/app/styles'
+
 interface DragHorizonProps {
   event: MouseEvent | React.MouseEvent<HTMLButtonElement, MouseEvent>
   leftCallback: () => void
@@ -42,4 +45,18 @@ export function changeToDate(time: Date): string {
 
 export function changeToTime(time: Date): string {
   return new Date(time.toString()).toLocaleString('ko')
+}
+
+/** Colors */
+
+export function getColorsByGroup<T extends ColorGroup>(color: T): ColorsByGroup<T> {
+  return Object.entries(COLORS)
+    .filter(([key]) => key.startsWith(`${color}_`))
+    .reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: value
+      }),
+      {} as ColorsByGroup<T>
+    )
 }


### PR DESCRIPTION
This pull request includes several changes to refactor and reorganize color-related types and utility functions in the codebase. The most important changes include moving type definitions to a more appropriate file, removing redundant code, and consolidating utility functions.

Refactoring and reorganization:

* Moved color-related type definitions (`HexColor`, `ColorGroup`, `ColorShade`, `BasicColor`, `Colors`, `ColorsByGroup`, `BasicColors`) from `client/app/styles/colors.ts` to `client/app/types/styles.ts`.
* Removed redundant color-related type definitions and utility functions from `client/app/styles/colors.ts` and updated the import statement to use the new location of the types. [[1]](diffhunk://#diff-ff24af70d6e097c4b4a5332f0c678771a74a1fa1914d2ef3d286320eb88777e9L1-R1) [[2]](diffhunk://#diff-ff24af70d6e097c4b4a5332f0c678771a74a1fa1914d2ef3d286320eb88777e9L46-L95)

Consolidation of utility functions:

* Moved the `getColorsByGroup` utility function to `client/app/utils/common.ts` and updated it to be a generic function that can handle any `ColorGroup`. [[1]](diffhunk://#diff-9d16271046ba0b342889410843e334ae72a8b4d1db8c9502f8df0ad6bb91fc68R3-R5) [[2]](diffhunk://#diff-9d16271046ba0b342889410843e334ae72a8b4d1db8c9502f8df0ad6bb91fc68R49-R62)