### PR TITLE
Move stories components folder to stories common folder

### DIFF
--- a/client/app/stories/common/Button.stories.ts
+++ b/client/app/stories/common/Button.stories.ts
@@ -4,7 +4,7 @@ import { Button } from '@/app/components'
 import { buttonsTheme } from '@/app/types'
 
 const meta = {
-  title: 'Example/Components/Button',
+  title: 'Example/Common/Button',
   component: Button,
   parameters: {
     layout: 'centered',

--- a/client/app/stories/common/Modal.stories.tsx
+++ b/client/app/stories/common/Modal.stories.tsx
@@ -7,7 +7,7 @@ const ModalContents = () => {
 }
 
 const meta = {
-  title: 'Example/Components/Modal',
+  title: 'Example/Common/Modal',
   component: AgreementModal,
   parameters: {
     viewport: {

--- a/client/app/stories/common/Title.stories.tsx
+++ b/client/app/stories/common/Title.stories.tsx
@@ -19,7 +19,7 @@ function Title({ children }: Props) {
 }
 
 const meta = {
-  title: 'Example/Components/Title',
+  title: 'Example/Common/Title',
   component: Title,
   parameters: {
     viewport: {

--- a/client/app/stories/common/useCases/CreateCategory.stories.tsx
+++ b/client/app/stories/common/useCases/CreateCategory.stories.tsx
@@ -5,7 +5,7 @@ import { mediaQueryStandard } from '@/app/types'
 import { COLORS } from '@/app/styles'
 
 const usecaseCatagoryButton = {
-  title: 'Example/Components/UseCases',
+  title: 'Example/Common/UseCases',
   component: CreateCategory,
   parameters: {
     layout: 'centered',

--- a/client/app/stories/common/useCases/CreateTodolist.stories.tsx
+++ b/client/app/stories/common/useCases/CreateTodolist.stories.tsx
@@ -5,7 +5,7 @@ import { mediaQueryStandard } from '@/app/types'
 import { COLORS } from '@/app/styles'
 
 const usecaseTodolistButton = {
-  title: 'Example/Components/UseCases',
+  title: 'Example/Common/UseCases',
   component: CreateTodolist,
   parameters: {
     layout: 'left'


### PR DESCRIPTION
This pull request includes changes to rename several story files and update their titles to reflect the new directory structure. The goal is to move these files from the `components` directory to the `common` directory.

File renaming and title updates:

* `client/app/stories/components/Button.stories.ts` was renamed to `client/app/stories/common/Button.stories.ts`, and the title was updated from 'Example/Components/Button' to 'Example/Common/Button'.
* `client/app/stories/components/Modal.stories.tsx` was renamed to `client/app/stories/common/Modal.stories.tsx`, and the title was updated from 'Example/Components/Modal' to 'Example/Common/Modal'.
* `client/app/stories/components/Title.stories.tsx` was renamed to `client/app/stories/common/Title.stories.tsx`, and the title was updated from 'Example/Components/Title' to 'Example/Common/Title'.
* `client/app/stories/components/useCases/CreateCategory.stories.tsx` was renamed to `client/app/stories/common/useCases/CreateCategory.stories.tsx`, and the title was updated from 'Example/Components/UseCases' to 'Example/Common/UseCases'.
* `client/app/stories/components/useCases/CreateTodolist.stories.tsx` was renamed to `client/app/stories/common/useCases/CreateTodolist.stories.tsx`, and the title was updated from 'Example/Components/UseCases' to 'Example/Common/UseCases'.