### PR TITLE
Rename components to DesignSystemDisplay and DesignSystemGuideRow components

### DIFF
--- a/client/app/stories/components/BorderRadiuses.tsx
+++ b/client/app/stories/components/BorderRadiuses.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { DesignSystemComponent, borderRadius } from '@/app/types'
 import { BORDER_RADIUS_SIZES } from '@/app/styles'
-import { DesignSystemPlate } from '@/app/stories/components'
+import { DesignSystemGuideRow } from '@/app/stories/components'
 
 export function BorderRadiuses() {
   const sizes: DesignSystemComponent<borderRadius>[] = [
@@ -25,5 +25,5 @@ export function BorderRadiuses() {
     }
   ]
 
-  return <DesignSystemPlate list={sizes} />
+  return <DesignSystemGuideRow list={sizes} />
 }

--- a/client/app/stories/components/BoxShadows.tsx
+++ b/client/app/stories/components/BoxShadows.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { DesignSystemComponent, boxShadow } from '@/app/types'
 import { BORDER_RADIUS_SIZES, BOX_SHADOWS } from '@/app/styles'
-import { DesignSystemPlate } from '@/app/stories/components'
+import { DesignSystemGuideRow } from '@/app/stories/components'
 
 export function BoxShadows() {
   const shadows: DesignSystemComponent<boxShadow>[] = [
@@ -19,5 +19,5 @@ export function BoxShadows() {
     }
   ]
 
-  return <DesignSystemPlate list={shadows} />
+  return <DesignSystemGuideRow list={shadows} />
 }

--- a/client/app/stories/components/DesignSystemDisplay.tsx
+++ b/client/app/stories/components/DesignSystemDisplay.tsx
@@ -19,11 +19,10 @@ interface ComponentStyleProps {
   styles: RuleSet[]
 }
 
-interface Props {
+interface Props extends ComponentStyleProps {
   children: React.ReactNode
-  styles: RuleSet[]
 }
 
-export function Example({ children, styles }: Props) {
+export function DesignSystemDisplay({ children, styles }: Props) {
   return <Components styles={styles}>{children}</Components>
 }

--- a/client/app/stories/components/DesignSystemGuideRow.tsx
+++ b/client/app/stories/components/DesignSystemGuideRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Example } from '@/app/stories/components'
+import { DesignSystemDisplay } from '@/app/stories/components'
 import { COLORS } from '@/app/styles'
 import { DesignSystemComponent } from '@/app/types'
 
@@ -33,7 +33,7 @@ interface Props<T extends string> {
   list: DesignSystemComponent<T>[]
 }
 
-export function DesignSystemPlate<T extends string>({ list }: Props<T>) {
+export function DesignSystemGuideRow<T extends string>({ list }: Props<T>) {
   return (
     <Components>
       {list.map((item) => (
@@ -42,7 +42,7 @@ export function DesignSystemPlate<T extends string>({ list }: Props<T>) {
             <Title>{item.name.toUpperCase()}</Title>
             <SubTitle>{item.description}</SubTitle>
           </TitleWrapper>
-          <Example styles={item.styles}>{item.value}</Example>
+          <DesignSystemDisplay styles={item.styles}>{item.value}</DesignSystemDisplay>
         </Component>
       ))}
     </Components>

--- a/client/app/stories/components/index.ts
+++ b/client/app/stories/components/index.ts
@@ -1,4 +1,4 @@
 export * from './BorderRadiuses'
 export * from './BoxShadows'
-export * from './DesignSystemPlate'
-export * from './Example'
+export * from './DesignSystemGuideRow'
+export * from './DesignSystemDisplay'


### PR DESCRIPTION
This pull request includes several changes to the `client/app/stories/components` directory, primarily focused on renaming components and updating their references across multiple files. The most important changes include renaming `DesignSystemPlate` to `DesignSystemGuideRow`, renaming `Example` to `DesignSystemDisplay`, and updating the relevant imports and usage within the components.

Component renaming and updates:

* [`client/app/stories/components/BorderRadiuses.tsx`](diffhunk://#diff-6b19859aca4a7fa26e83bcd29a54be3bc10e8ae6b4b3ebc93fbcf462d1de084aL4-R4): Changed import and usage of `DesignSystemPlate` to `DesignSystemGuideRow`. [[1]](diffhunk://#diff-6b19859aca4a7fa26e83bcd29a54be3bc10e8ae6b4b3ebc93fbcf462d1de084aL4-R4) [[2]](diffhunk://#diff-6b19859aca4a7fa26e83bcd29a54be3bc10e8ae6b4b3ebc93fbcf462d1de084aL28-R28)
* [`client/app/stories/components/BoxShadows.tsx`](diffhunk://#diff-f8f031352f799adc2923521d7554febed986c65e13d3016aa239d0df4c4dc8caL4-R4): Changed import and usage of `DesignSystemPlate` to `DesignSystemGuideRow`. [[1]](diffhunk://#diff-f8f031352f799adc2923521d7554febed986c65e13d3016aa239d0df4c4dc8caL4-R4) [[2]](diffhunk://#diff-f8f031352f799adc2923521d7554febed986c65e13d3016aa239d0df4c4dc8caL22-R22)
* [`client/app/stories/components/DesignSystemDisplay.tsx`](diffhunk://#diff-5e6c861e832245b43e99588c9a33c004d25a04b27cfb577af5c126f7d4a9f14dL22-R26): Renamed from `Example.tsx` and updated the component name and props.
* [`client/app/stories/components/DesignSystemGuideRow.tsx`](diffhunk://#diff-a18bc6bb7af21ade634ca3da3742029bbf72f86c6f73e839d0ff93906b9ad727L3-R3): Renamed from `DesignSystemPlate.tsx` and updated the import and usage of `Example` to `DesignSystemDisplay`. [[1]](diffhunk://#diff-a18bc6bb7af21ade634ca3da3742029bbf72f86c6f73e839d0ff93906b9ad727L3-R3) [[2]](diffhunk://#diff-a18bc6bb7af21ade634ca3da3742029bbf72f86c6f73e839d0ff93906b9ad727L36-R36) [[3]](diffhunk://#diff-a18bc6bb7af21ade634ca3da3742029bbf72f86c6f73e839d0ff93906b9ad727L45-R45)
* [`client/app/stories/components/index.ts`](diffhunk://#diff-4a269298ceac05f52782cc78ab49d42eb6e7decbd173fb8bda375cc4a7516c24L3-R4): Updated exports to reflect the renamed components.