### PR TITLE
Fix/styled components camel case

### DIFF
--- a/client/app/(main)/todolist/components/TodoItem.tsx
+++ b/client/app/(main)/todolist/components/TodoItem.tsx
@@ -15,12 +15,12 @@ const TodoWrapper = styled.div<TodolistWrapperStylesProps>`
   justify-content: space-between;
   padding: 0.75rem 1rem;
   background-color: ${COLORS.WHITE};
-  opacity: ${({ isDragging }) => (isDragging ? 0.5 : 1)};
+  opacity: ${({ $isDragging }) => ($isDragging ? 0.5 : 1)};
   transform: ${({ stringTransform }) => CSS.Translate.toString(stringTransform)};
   transition: ${({ transition }) => transition};
-  border: ${({ isDragging }) => (isDragging ? '1px solid red' : 'none')};
-  border-bottom: ${({ isDragging }) => (isDragging ? '1px solid red' : `1px solid ${COLORS.GRAY_200}`)};
-  z-index: ${({ isDragging }) => (isDragging ? '100' : `1`)};
+  border: ${({ $isDragging }) => ($isDragging ? '1px solid red' : 'none')};
+  border-bottom: ${({ $isDragging }) => ($isDragging ? '1px solid red' : `1px solid ${COLORS.GRAY_200}`)};
+  z-index: ${({ $isDragging }) => ($isDragging ? '100' : `1`)};
   user-select: none;
   cursor: move;
 
@@ -57,7 +57,7 @@ const TodoIcons = styled.i`
 `
 
 interface TodolistWrapperStylesProps {
-  isDragging: boolean
+  $isDragging: boolean
   stringTransform: Transform | null
   transition?: string
 }
@@ -76,7 +76,7 @@ function TodoItemComponent({ todo, handleCompleteTodo, handleEditModalOpen }: Pr
       id={`${todo.id}-todo`}
       {...attributes}
       {...listeners}
-      isDragging={isDragging}
+      $isDragging={isDragging}
       stringTransform={transform}
       transition={transition}
       ref={setNodeRef}

--- a/client/app/(main)/todolist/components/TodoItem.tsx
+++ b/client/app/(main)/todolist/components/TodoItem.tsx
@@ -16,7 +16,7 @@ const TodoWrapper = styled.div<TodolistWrapperStylesProps>`
   padding: 0.75rem 1rem;
   background-color: ${COLORS.WHITE};
   opacity: ${({ $isDragging }) => ($isDragging ? 0.5 : 1)};
-  transform: ${({ stringTransform }) => CSS.Translate.toString(stringTransform)};
+  transform: ${({ $stringTransform }) => CSS.Translate.toString($stringTransform)};
   transition: ${({ transition }) => transition};
   border: ${({ $isDragging }) => ($isDragging ? '1px solid red' : 'none')};
   border-bottom: ${({ $isDragging }) => ($isDragging ? '1px solid red' : `1px solid ${COLORS.GRAY_200}`)};
@@ -58,7 +58,7 @@ const TodoIcons = styled.i`
 
 interface TodolistWrapperStylesProps {
   $isDragging: boolean
-  stringTransform: Transform | null
+  $stringTransform: Transform | null
   transition?: string
 }
 
@@ -77,7 +77,7 @@ function TodoItemComponent({ todo, handleCompleteTodo, handleEditModalOpen }: Pr
       {...attributes}
       {...listeners}
       $isDragging={isDragging}
-      stringTransform={transform}
+      $stringTransform={transform}
       transition={transition}
       ref={setNodeRef}
     >

--- a/client/app/components/Button.tsx
+++ b/client/app/components/Button.tsx
@@ -20,7 +20,7 @@ interface Props extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLB
 
 export function Button({ children, size, style, theme = buttonsTheme.BRIGHT, onClick, ...rest }: Props) {
   return (
-    <StyledButton size={size} stylestheme={theme} style={style} onClick={onClick} {...rest}>
+    <StyledButton size={size} $stylestheme={theme} style={style} onClick={onClick} {...rest}>
       {children}
     </StyledButton>
   )

--- a/client/app/styles/button.ts
+++ b/client/app/styles/button.ts
@@ -12,18 +12,18 @@ export const BUTTON_DEFAULT_STYLE = css<ButtonStyleProps>`
   user-select: none;
 
   background-color: ${(props) => {
-    return props.stylestheme === buttonsTheme.BRIGHT ? COLORS.RED_600 : COLORS.GRAY_500
+    return props.$stylestheme === buttonsTheme.BRIGHT ? COLORS.RED_600 : COLORS.GRAY_500
   }};
 
   &:hover {
     background-color: ${(props) => {
-      return props.stylestheme === buttonsTheme.BRIGHT ? COLORS.RED_500 : COLORS.GRAY_400
+      return props.$stylestheme === buttonsTheme.BRIGHT ? COLORS.RED_500 : COLORS.GRAY_400
     }};
   }
 
   &:active {
     background-color: ${(props) => {
-      return props.stylestheme === buttonsTheme.BRIGHT ? COLORS.RED_600 : COLORS.GRAY_500
+      return props.$stylestheme === buttonsTheme.BRIGHT ? COLORS.RED_600 : COLORS.GRAY_500
     }};
   }
 `

--- a/client/app/types/styles.ts
+++ b/client/app/types/styles.ts
@@ -31,7 +31,7 @@ export enum sectionWidth {
 }
 
 export interface ButtonStyleProps {
-  stylestheme: buttonsTheme
+  $stylestheme: buttonsTheme
   size: buttonSize
 }
 


### PR DESCRIPTION
This pull request includes changes to the `client/app` directory, primarily focusing on updating styled-component props to use the ` prefix. This change ensures consistency and avoids potential conflicts with standard HTML attributes.

#182 

Changes to styled-component props:

* [`client/app/(main)/todolist/components/TodoItem.tsx`](diffhunk://#diff-66d049fa3ad4e94cb2b25e0a575996ab2f84ea4cd73d5b1f7f1fa2f651c15744L18-R23): Updated `isDragging` and `stringTransform` props to `$isDragging` and `$stringTransform` in `TodoWrapper`, `TodolistWrapperStylesProps`, and `TodoItemComponent` to follow the convention of using the ` prefix for styled-component props. [[1]](diffhunk://#diff-66d049fa3ad4e94cb2b25e0a575996ab2f84ea4cd73d5b1f7f1fa2f651c15744L18-R23) [[2]](diffhunk://#diff-66d049fa3ad4e94cb2b25e0a575996ab2f84ea4cd73d5b1f7f1fa2f651c15744L60-R61) [[3]](diffhunk://#diff-66d049fa3ad4e94cb2b25e0a575996ab2f84ea4cd73d5b1f7f1fa2f651c15744L79-R80)

* [`client/app/components/Button.tsx`](diffhunk://#diff-8a8388adab6aa8723d49bc664ff14f306b3e641ee3c452cfba39c9e6c7ee9882L23-R23): Updated `stylestheme` prop to `$stylestheme` in the `Button` component to follow the convention of using the ` prefix for styled-component props.

* [`client/app/styles/button.ts`](diffhunk://#diff-c203583ba4263bad891466a033a874283f8d1aa313d067fcf0d45ae261c1d5bfL15-R26): Updated `stylestheme` prop to `$stylestheme` in the `BUTTON_DEFAULT_STYLE` to follow the convention of using the ` prefix for styled-component props.

* [`client/app/types/styles.ts`](diffhunk://#diff-ed88be69065ba278d41e0bfce32f30b33caf0a667cc879bf9d2116573fa4141fL34-R34): Updated `stylestheme` prop to `$stylestheme` in the `ButtonStyleProps` interface to follow the convention of using the ` prefix for styled-component props.