### PR TITLE
Refactor useTodolist to use newFetchToBackend

### DIFF
--- a/client/app/(main)/todolist/[categoryId]/page.tsx
+++ b/client/app/(main)/todolist/[categoryId]/page.tsx
@@ -1,7 +1,7 @@
 import { TodolistHeader, TodolistDisplay, TodolistSection } from '@/app/(main)/todolist/components'
 import { getCategoryById } from '@/app/(main)/category/api'
-import { getTodolistByCategoryId } from '@/app/(main)/todolist/api'
-import { UUID } from '@/app/types'
+import { GetResponseTodolist, UUID } from '@/app/types'
+import { newFetchToBackend } from '@/app/utils'
 
 interface Props {
   params: { categoryId: UUID }
@@ -9,20 +9,35 @@ interface Props {
 
 export default async function page({ params: { categoryId: categoryId } }: Props) {
   const responseCategory = await getCategoryById(categoryId)
-  const responseTodolist = await getTodolistByCategoryId(categoryId)
+  const responseTodolist = await newFetchToBackend<GetResponseTodolist>(`/todolist/${categoryId}?checked=false`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    cache: 'no-cache'
+  })
 
   const { response: category } = responseCategory
+  const { response: todolist } = responseTodolist
 
   const getTodolist = async () => {
     'use server'
-    const result = await getTodolistByCategoryId(categoryId)
-    return result.data
+    const responseNewTodolist = await newFetchToBackend<GetResponseTodolist>(`/todolist/${categoryId}?checked=false`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      cache: 'no-cache'
+    })
+
+    const { response } = responseNewTodolist
+    return response.data
   }
 
   return (
     <TodolistSection>
       <TodolistHeader category={category} />
-      <TodolistDisplay categoryId={category.id} todolist={responseTodolist.data} getTodolist={getTodolist} />
+      <TodolistDisplay categoryId={category.id} todolist={todolist.data} getTodolist={getTodolist} />
     </TodolistSection>
   )
 }

--- a/client/app/(main)/todolist/hooks/useTodolist.ts
+++ b/client/app/(main)/todolist/hooks/useTodolist.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { createTodolist, updateTodolist } from '@/app/(main)/todolist/api'
 import { CreateTodoDto, Todo, UpdateTodoDTO } from '@/app/types'
+import { newFetchToBackend } from '@/app/utils'
 
 interface Props {
   categoryId: string
@@ -17,7 +17,14 @@ export function useTodolist({ categoryId, todolist, getTodolist }: Props) {
   }
 
   const handleEditTodo = async (updated: UpdateTodoDTO) => {
-    await updateTodolist(updated)
+    await newFetchToBackend(`/todolist`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(updated)
+    })
+
     await setNewTodolist()
   }
 
@@ -28,7 +35,13 @@ export function useTodolist({ categoryId, todolist, getTodolist }: Props) {
       checked: !todo.checked
     }
 
-    await updateTodolist(updated)
+    await newFetchToBackend(`/todolist`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(updated)
+    })
     await setNewTodolist()
 
     const audio = document.getElementById('audio') as HTMLAudioElement
@@ -41,7 +54,14 @@ export function useTodolist({ categoryId, todolist, getTodolist }: Props) {
       categoryId
     }
 
-    await createTodolist(createTodo)
+    await newFetchToBackend(`/todolist`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(createTodo)
+    })
+
     await setNewTodolist()
   }
 


### PR DESCRIPTION
This pull request includes several changes to the todolist functionality, primarily focusing on refactoring the API calls to use a new utility function, `newFetchToBackend`. The key changes are summarized below:

Refactoring API calls:

* `client/app/(main)/todolist/[categoryId]/page.tsx`: Replaced `getTodolistByCategoryId` with `newFetchToBackend` for fetching todolist data. ([client/app/(main)/todolist/[categoryId]/page.tsxL3-R40](diffhunk://#diff-e3be1158f2caf6655cd057b17fb7d04b5f37a9d1ca0039181d118b085185dd52L3-R40))
* [`client/app/(main)/todolist/hooks/useTodolist.ts`](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39L2-R3): Replaced `updateTodolist` and `createTodolist` with `newFetchToBackend` for updating and creating todolist items. [[1]](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39L2-R3) [[2]](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39L20-R27) [[3]](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39L31-R44) [[4]](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39L44-R64)