### PR TITLE
Refactor API call in Todolist page component

### DIFF
--- a/client/app/(main)/todolist/[categoryId]/page.tsx
+++ b/client/app/(main)/todolist/[categoryId]/page.tsx
@@ -1,7 +1,7 @@
 import { TodolistHeader, TodolistDisplay, TodolistSection } from '@/app/(main)/todolist/components'
 import { getCategoryById } from '@/app/(main)/category/api'
-import { GetResponseTodolist, UUID } from '@/app/types'
-import { newFetchToBackend } from '@/app/utils'
+import { getTodolistByCategoryId } from '@/app/(main)/todolist/api'
+import { UUID } from '@/app/types'
 
 interface Props {
   params: { categoryId: UUID }
@@ -9,27 +9,14 @@ interface Props {
 
 export default async function page({ params: { categoryId: categoryId } }: Props) {
   const responseCategory = await getCategoryById(categoryId)
-  const responseTodolist = await newFetchToBackend<GetResponseTodolist>(`/todolist/${categoryId}?checked=false`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    cache: 'no-cache'
-  })
+  const responseTodolist = await getTodolistByCategoryId(categoryId)
 
   const { response: category } = responseCategory
   const { response: todolist } = responseTodolist
 
   const getTodolist = async () => {
     'use server'
-    const responseNewTodolist = await newFetchToBackend<GetResponseTodolist>(`/todolist/${categoryId}?checked=false`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      cache: 'no-cache'
-    })
-
+    const responseNewTodolist = await getTodolistByCategoryId(categoryId)
     const { response } = responseNewTodolist
     return response.data
   }

--- a/client/app/(main)/todolist/api/index.ts
+++ b/client/app/(main)/todolist/api/index.ts
@@ -1,4 +1,4 @@
-import { fetchToWebServer } from '@/app/utils'
+import { fetchToWebServer, newFetchToBackend } from '@/app/utils'
 import { CreateTodoDto, GetResponseTodolist, GetResponseTodolistByDates, Todo, UUID, UpdateTodoDTO } from '@/app/types'
 
 export async function createTodolist(createTodo: CreateTodoDto) {
@@ -14,7 +14,7 @@ export async function createTodolist(createTodo: CreateTodoDto) {
 }
 
 export async function getTodolistByCategoryId(categoryId: UUID) {
-  const response = await fetchToWebServer<GetResponseTodolist>(`/api/todolist/${categoryId}?checked=false`, {
+  const response = await newFetchToBackend<GetResponseTodolist>(`/todolist/${categoryId}?checked=false`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json'

--- a/client/app/(main)/todolist/api/index.ts
+++ b/client/app/(main)/todolist/api/index.ts
@@ -37,13 +37,13 @@ export async function getTodolistByDates(categoryId: UUID) {
   return response
 }
 
-export async function updateTodolist(updatedTodo: UpdateTodoDTO) {
-  const response = await fetchToWebServer(`/api/todolist`, {
+export async function updateTodolist(updated: UpdateTodoDTO) {
+  const response = await newFetchToBackend(`/todolist`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify(updatedTodo)
+    body: JSON.stringify(updated)
   })
 
   return response

--- a/client/app/(main)/todolist/api/index.ts
+++ b/client/app/(main)/todolist/api/index.ts
@@ -58,7 +58,7 @@ export async function saveTodolistOrder(todolist: Todo[]) {
     }
   })
 
-  const response = await fetchToWebServer(`/api/todolist/order`, {
+  const response = await newFetchToBackend(`/todolist/order`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json'

--- a/client/app/(main)/todolist/api/index.ts
+++ b/client/app/(main)/todolist/api/index.ts
@@ -2,7 +2,7 @@ import { fetchToWebServer, newFetchToBackend } from '@/app/utils'
 import { CreateTodoDto, GetResponseTodolist, GetResponseTodolistByDates, Todo, UUID, UpdateTodoDTO } from '@/app/types'
 
 export async function createTodolist(createTodo: CreateTodoDto) {
-  const response = await fetchToWebServer(`/api/todolist`, {
+  const response = await newFetchToBackend(`/todolist`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'

--- a/client/app/(main)/todolist/hooks/useTodolist.ts
+++ b/client/app/(main)/todolist/hooks/useTodolist.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import { CreateTodoDto, Todo, UpdateTodoDTO } from '@/app/types'
+import { updateTodolist } from '@/app/(main)/todolist/api'
 import { newFetchToBackend } from '@/app/utils'
+import { CreateTodoDto, Todo, UpdateTodoDTO } from '@/app/types'
 
 interface Props {
   categoryId: string
@@ -17,14 +18,7 @@ export function useTodolist({ categoryId, todolist, getTodolist }: Props) {
   }
 
   const handleEditTodo = async (updated: UpdateTodoDTO) => {
-    await newFetchToBackend(`/todolist`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(updated)
-    })
-
+    await updateTodolist(updated)
     await setNewTodolist()
   }
 
@@ -34,14 +28,7 @@ export function useTodolist({ categoryId, todolist, getTodolist }: Props) {
       title: todo.title,
       checked: !todo.checked
     }
-
-    await newFetchToBackend(`/todolist`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(updated)
-    })
+    await updateTodolist(updated)
     await setNewTodolist()
 
     const audio = document.getElementById('audio') as HTMLAudioElement

--- a/client/app/(main)/todolist/hooks/useTodolist.ts
+++ b/client/app/(main)/todolist/hooks/useTodolist.ts
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-import { updateTodolist } from '@/app/(main)/todolist/api'
-import { newFetchToBackend } from '@/app/utils'
+import { createTodolist, updateTodolist } from '@/app/(main)/todolist/api'
 import { CreateTodoDto, Todo, UpdateTodoDTO } from '@/app/types'
 
 interface Props {
@@ -40,15 +39,7 @@ export function useTodolist({ categoryId, todolist, getTodolist }: Props) {
       title,
       categoryId
     }
-
-    await newFetchToBackend(`/todolist`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(createTodo)
-    })
-
+    await createTodolist(createTodo)
     await setNewTodolist()
   }
 


### PR DESCRIPTION
This pull request focuses on refactoring the code to replace the usage of `fetchToWebServer` with `newFetchToBackend` for various API calls in the todolist feature. Additionally, it updates the hooks and components to use the new API functions.

### Code Refactoring:

* `client/app/(main)/todolist/[categoryId]/page.tsx`: Replaced direct API calls with `getTodolistByCategoryId` to fetch the todolist by category ID. ([client/app/(main)/todolist/[categoryId]/page.tsxL3-R19](diffhunk://#diff-e3be1158f2caf6655cd057b17fb7d04b5f37a9d1ca0039181d118b085185dd52L3-R19))

* [`client/app/(main)/todolist/api/index.ts`](diffhunk://#diff-3b09df7d471ed2657f111cf536d40895b616a91e1f7c43c7df8185d1f54fb672L1-R5): Updated functions `createTodolist`, `getTodolistByCategoryId`, `updateTodolist`, and `saveTodolistOrder` to use `newFetchToBackend` instead of `fetchToWebServer`. [[1]](diffhunk://#diff-3b09df7d471ed2657f111cf536d40895b616a91e1f7c43c7df8185d1f54fb672L1-R5) [[2]](diffhunk://#diff-3b09df7d471ed2657f111cf536d40895b616a91e1f7c43c7df8185d1f54fb672L17-R17) [[3]](diffhunk://#diff-3b09df7d471ed2657f111cf536d40895b616a91e1f7c43c7df8185d1f54fb672L40-R46) [[4]](diffhunk://#diff-3b09df7d471ed2657f111cf536d40895b616a91e1f7c43c7df8185d1f54fb672L61-R61)

* [`client/app/(main)/todolist/hooks/useTodolist.ts`](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39R2-L3): Modified the hook to use the updated API functions `createTodolist` and `updateTodolist` instead of making direct API calls. [[1]](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39R2-L3) [[2]](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39L20-R20) [[3]](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39L37-R30) [[4]](diffhunk://#diff-5c4680b7b2b65aebc6d9e951c276866d1d3f9054bc332a6a7ac6e838bc6eca39L56-R42)