### PR TITLE
Update .gitignore and docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .next
-**/*.env
+.env.**/*
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres
     env_file:
-      - .server.env
+      - .env
     profiles:
       - infra
       - all
@@ -23,7 +23,8 @@ services:
 
   backend:
     env_file:
-      - .server.env
+      - .env
+      - .env.server
     image: ${SERVICE_BACKEND_CONTAINER_NAME}
     build: ./server/.
     profiles:
@@ -38,7 +39,8 @@ services:
 
   client:
     env_file:
-      - .client.env
+      - .env
+      - .env.client
     image: ${SERVICE_FRONTEND_CONTAINER_NAME}
     build: ./client/.
     profiles:


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file to standardize the environment file usage across different services.

Environment file standardization:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L7-R7): Changed the `env_file` for the `postgres` service to use `.env` instead of `.server.env`.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L26-R27): Updated the `env_file` for the `backend` service to include both `.env` and `.env.server` instead of just `.server.env`.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L41-R43): Modified the `env_file` for the `client` service to include both `.env` and `.env.client` instead of just `.client.env`.