### PR TITLE
Add port mapping for backend and frontend services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     container_name: ${SERVICE_BACKEND_CONTAINER_NAME}
     expose:
       - "${SERVER_PORT}"
+    ports:
+      - "${SERVER_PORT}:${SERVER_PORT}"
     networks:
       - todolist
     restart: always
@@ -46,7 +48,7 @@ services:
     profiles:
       - services
     container_name: ${SERVICE_FRONTEND_CONTAINER_NAME}
-    expose:
+    ports:
       - "${CLIENT_PORT}:${CLIENT_PORT}"
     networks:
       - todolist


### PR DESCRIPTION
This pull request includes updates to the `docker-compose.yml` file to improve the configuration of service ports. The most important changes involve the addition of the `ports` directive to expose the necessary ports for both the backend and frontend services.

Configuration updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R36-R37): Added the `ports` directive for the backend service to map the server port to the host.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L49-R51): Replaced the `expose` directive with the `ports` directive for the frontend service to ensure the client port is correctly mapped to the host.