### PR TITLE
Update BACKEND_SERVER_URL based on environment variables

### DIFF
--- a/client/app/utils/customFetch.ts
+++ b/client/app/utils/customFetch.ts
@@ -1,6 +1,13 @@
 export type EndPoint = string
 export type HTTPMethods = 'GET' | 'POST' | 'PATCH' | 'DELETE'
-export const BACKEND_SERVER_URL = process.env.NEXT_PUBLIC_BACKEND_SERVER_URL || 'http://localhost:3000'
+
+const UrlMap = {
+  test: 'http://localhost:3000',
+  development: process.env.NEXT_PUBLIC_BACKEND_DEVELOPMENT,
+  production: process.env.NEXT_PUBLIC_BACKEND_PRODUCTION
+}
+
+export const BACKEND_SERVER_URL = UrlMap[process.env.NODE_ENV]
 
 interface CustomRequestInit extends RequestInit {
   method: HTTPMethods


### PR DESCRIPTION
This pull request includes a change to the `client/app/utils/customFetch.ts` file to dynamically set the backend server URL based on the environment. The most important change is the introduction of a `UrlMap` object to map different environments to their respective URLs.

* [`client/app/utils/customFetch.ts`](diffhunk://#diff-34b7398f2ac8b91f8bf7dd7c276f29b90faaad1b06878041d0b891ee4b550f56L3-R10): Introduced a `UrlMap` object to map different environments (test, development, and production) to their respective backend server URLs. The `BACKEND_SERVER_URL` is now set dynamically based on the `NODE_ENV` environment variable.