### PR TITLE
Add reset script to delete Docker containers and environment variables

### DIFF
--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+
+confirm_reset() {
+    while true; do
+        read -p "Are you sure you want to delete all Docker containers and environment variables? (yes/no) " yn
+        case $yn in
+            [Yy]* ) return 0;;
+            [Nn]* ) return 1;;
+            * ) echo "Sorry, please answer yes or no.";;
+        esac
+    done
+}
+
+if ! confirm_reset; then
+    echo "The task was canceled."
+    exit 1
+fi
+
+echo "The reset task is going."
+
+rm ../.env ../client/.env ../server/.env || true
+docker rm -f frontend backend postgres
+docker system prune -a -f
+
+echo "The reset task is done."


### PR DESCRIPTION
This pull request introduces a new script to reset Docker containers and environment variables. The script includes a confirmation prompt to ensure the user wants to proceed with the reset. Here are the key changes:

* Added a new script `reset.sh` to handle the reset process.
  * The script includes a confirmation function to prompt the user before proceeding with the reset.
  * It removes environment variable files and stops Docker containers.
  * It performs a system prune to remove all unused Docker data.