### PR TITLE
Refactor client build configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,7 @@ services:
 
   client:
     image: ${SERVICE_FRONTEND_CONTAINER_NAME}
-    build:
-      context: ./client
-      args:
-        NODE_ENV: ${NODE_ENV}
-    environment:
-      - NODE_ENV=${NODE_ENV}
+    build: ./client
     profiles:
       - services
     container_name: ${SERVICE_FRONTEND_CONTAINER_NAME}


### PR DESCRIPTION
This pull request includes a change to the `docker-compose.yml` file to simplify the configuration of the `client` service.

Configuration simplification:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L39-R39): Simplified the `client` service configuration by removing redundant `build` arguments and environment variables, and consolidating the `build` context into a single line.