### PR TITLE
Update backend server URL in customFetch.ts and docker.development.deploy

### DIFF
--- a/client/app/utils/customFetch.ts
+++ b/client/app/utils/customFetch.ts
@@ -1,7 +1,7 @@
 export type EndPoint = string
 export type HTTPMethods = 'GET' | 'POST' | 'PATCH' | 'DELETE'
 
-export const BACKEND_SERVER_URL = process.env.NEXT_PUBLIC_BACKEND_URL
+export const BACKEND_SERVER_URL = typeof window === 'undefined' ? process.env.NEXT_PUBLIC_BACKEND_URL : 'http://localhost:3000'
 
 interface CustomRequestInit extends RequestInit {
   method: HTTPMethods

--- a/client/scripts/docker.development.deploy.sh
+++ b/client/scripts/docker.development.deploy.sh
@@ -3,7 +3,7 @@ set -e
 cd "$(dirname "$0")"
 source ../.env
 
-NEW_VALUE="http://backend:3000"
+NEW_VALUE="http://localhost:3000"
 ENV_FILE="../.env"
 
 if [ -f "$ENV_FILE" ]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,4 +41,4 @@ docker-compose -f ../docker-compose.yml --profile infra up -d
 infra_setting
 docker-compose -f ../docker-compose.yml --profile services up -d
 
-docker exec $SERVICE_FRONTEND_CONTAINER_NAME bash ./scripts/docker.development.deploy.sh
+# docker exec $SERVICE_FRONTEND_CONTAINER_NAME bash ./scripts/docker.development.deploy.sh


### PR DESCRIPTION
This pull request includes several changes to the development and deployment scripts, as well as the `customFetch.ts` utility file. The most important changes involve modifying URLs for local development and adjusting the deployment script.

Changes to URLs for local development:

* [`client/app/utils/customFetch.ts`](diffhunk://#diff-34b7398f2ac8b91f8bf7dd7c276f29b90faaad1b06878041d0b891ee4b550f56L4-R4): Changed `BACKEND_SERVER_URL` to use `http://localhost:3000` when running in a browser environment.
* [`client/scripts/docker.development.deploy.sh`](diffhunk://#diff-fc5c29e89e61dbce24489c70f7b2a02b9c342b053ab38152242c53196e7811e6L6-R6): Updated `NEW_VALUE` to use `http://localhost:3000` instead of `http://backend:3000`.

Adjustments to deployment script:

* [`scripts/deploy.sh`](diffhunk://#diff-37cb4e5e5a1884f59247915193e6246be6df0129ae8e233b8a78c0c91d47dc04L44-R44): Commented out the line that executes `docker.development.deploy.sh` inside the frontend container.