### PR TITLE
Refactor BACKEND_SERVER_URL initialization

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -12,4 +12,4 @@ RUN yarn build
 
 EXPOSE 3001
 
-CMD ["tail", "-f", "/dev/null"]
+CMD ["yarn", "start"]

--- a/client/app/utils/customFetch.ts
+++ b/client/app/utils/customFetch.ts
@@ -1,7 +1,15 @@
 export type EndPoint = string
 export type HTTPMethods = 'GET' | 'POST' | 'PATCH' | 'DELETE'
 
-export const BACKEND_SERVER_URL = typeof window === 'undefined' ? process.env.NEXT_PUBLIC_BACKEND_URL : 'http://localhost:3000'
+let serverUrl: string | undefined
+
+if (process.env.NEXT_PUBLIC_ENVIRONMENT === 'local') {
+  serverUrl = typeof window === 'undefined' ? process.env.NEXT_PUBLIC_BACKEND_URL : 'http://localhost:3000'
+} else {
+  serverUrl = process.env.NEXT_PUBLIC_BACKEND_URL
+}
+
+export const BACKEND_SERVER_URL = serverUrl
 
 interface CustomRequestInit extends RequestInit {
   method: HTTPMethods


### PR DESCRIPTION
This pull request includes changes to the `client/Dockerfile` and `client/app/utils/customFetch.ts` to improve the application's startup process and configuration handling. The most important changes are as follows:

### Dockerfile Update:
* Changed the command in `client/Dockerfile` to start the application using `yarn start` instead of tailing `/dev/null`. This ensures the application starts correctly when the Docker container is run.

### Configuration Handling:
* Updated `client/app/utils/customFetch.ts` to dynamically set the `BACKEND_SERVER_URL` based on the environment. If the environment is local, it sets the URL to `http://localhost:3000` when running in the browser, otherwise, it uses the value from `NEXT_PUBLIC_BACKEND_URL`. This change improves flexibility and correctness in different deployment environments.