### PR TITLE
Update deploy script to include database dump import

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,24 +10,10 @@ infra_setting() {
         sleep 1
     done
 
-    docker exec $SERVICE_BACKEND_CONTAINER_NAME /bin/bash -c '
-        counter=0
-        while ! { [ -f ./dist/database/data-source.js ] || [ -f /app/dist/database/data-source.js ]; } && [ $counter -lt 30 ]; do
-            echo "Waiting for data-source.js to be created..."
-            sleep 2
-            counter=$((counter + 1))
-        done
-        if ! { [ -f ./dist/database/data-source.js ] || [ -f /app/dist/database/data-source.js ]; }; then
-            echo "Timeout waiting for data-source.js"
-            exit 1
-        fi
-    '
-    
-    docker exec $SERVICE_BACKEND_CONTAINER_NAME yarn migration:show
-    docker exec $SERVICE_BACKEND_CONTAINER_NAME yarn migration:run
-    docker exec $SERVICE_BACKEND_CONTAINER_NAME yarn migration:show
-    docker exec -i $DB_CONTAINER_NAME psql -U $DB_USERNAME -d $DB_DATABASE -c '\dt'
+    docker cp ../temp/dump.sql postgres:/home/
+    docker exec postgres psql -U benny -d postgres -f /home/dump.sql
 }
+
 docker network create $DOCKER_NETWORK || true
 
 cat ../envs/.client.env ../envs/.server.env ../envs/.infra.env  > ../.env


### PR DESCRIPTION
This pull request includes significant changes to the `scripts/deploy.sh` file, focusing on simplifying the database setup process during deployment. The most important changes involve removing the previous method of waiting for `data-source.js` and running migrations, and replacing it with a more straightforward approach of copying and executing a SQL dump file.

Database setup simplification:

* [`scripts/deploy.sh`](diffhunk://#diff-37cb4e5e5a1884f59247915193e6246be6df0129ae8e233b8a78c0c91d47dc04L13-R16): Removed the loop that waits for `data-source.js` to be created and the subsequent migration commands. Replaced it with commands to copy a SQL dump file to the PostgreSQL container and execute it.