### PR TITLE
Refactor build paths for backend and frontend services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - postgres
     image: ${SERVICE_BACKEND_CONTAINER_NAME}
-    build: ./server/.
+    build: ./packages/server
     profiles:
       - infra
     container_name: ${SERVICE_BACKEND_CONTAINER_NAME}
@@ -36,7 +36,7 @@ services:
 
   client:
     image: ${SERVICE_FRONTEND_CONTAINER_NAME}
-    build: ./client
+    build: ./packages/client
     profiles:
       - services
     container_name: ${SERVICE_FRONTEND_CONTAINER_NAME}


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file to update the build paths for the backend and frontend services.

Changes in `services:`:

* Updated the build path for the backend service from `./server/.` to `./packages/server`.
* Updated the build path for the frontend service from `./client` to `./packages/client`.