### PR TITLE
Add password update for database user

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -12,6 +12,7 @@ infra_setting() {
 
     docker cp ../temp/dump.sql $DB_CONTAINER_NAME:/home/
     docker exec $DB_CONTAINER_NAME psql -U $DB_USERNAME -d $DB_CONTAINER_NAME -f /home/dump.sql
+    docker exec -it $DB_CONTAINER_NAME psql -U $DB_USERNAME -d $DB_DATABASE -c "ALTER USER $DB_USERNAME WITH PASSWORD '$DB_PASSWORD'"
 }
 
 docker network create $DOCKER_NETWORK || true


### PR DESCRIPTION
This pull request includes a change to the `infra_setting` function in the `scripts/deploy-local.sh` file to ensure that the database user password is updated during the deployment process.

* [`scripts/deploy-local.sh`](diffhunk://#diff-ebb77f825fa5a1c2efa2e85e8ae2cbaf434bf67945d20cdf415fa7e9d49bbbb6R15): Added a command to alter the database user password within the `infra_setting` function.