### PR TITLE
Update docker-compose.yml and .env.example files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,18 @@ services:
       - todolist
     restart: always
 
+    # stories:
+    #   image: ${SERVICE_STORYBOOK_CONTAINER_NAME}
+    #   build: ./packages/stories
+    #   profiles:
+    #     - services
+    #   container_name: ${SERVICE_STORYBOOK_CONTAINER_NAME}
+    #   ports:
+    #     - "${STORIES_PORT}:${STORIES_PORT}"
+    #   networks:
+    #     - todolist
+    #   restart: always
+
 networks:
   todolist:
     external: true

--- a/packages/client/.env.example
+++ b/packages/client/.env.example
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_BACKEND_SERVER_URL=http://localhost:3000
+NEXT_PUBLIC_BACKEND_URL=http://host.docker.internal:3000
 NEXT_PUBLIC_ENVIRONMENT=local

--- a/packages/stories/Dockerfile
+++ b/packages/stories/Dockerfile
@@ -1,15 +1,3 @@
 FROM node:20.12-buster-slim
 
 WORKDIR /app
-
-COPY package*.json ./
-
-RUN yarn install
-
-COPY . .
-
-RUN yarn build
-
-EXPOSE 3002
-
-CMD ["yarn", "start"]


### PR DESCRIPTION
This pull request includes several changes related to the `docker-compose.yml` file, environment variables, and the removal of a Dockerfile for the `stories` package. The most significant changes are as follows:

Environment Configuration:

* [`packages/client/.env.example`](diffhunk://#diff-72fb8cfef31ce867c7185e541752a08e1252d8db478af840a823f7f9249e8581L1-R1): Updated the environment variable `NEXT_PUBLIC_BACKEND_SERVER_URL` to `NEXT_PUBLIC_BACKEND_URL` and changed its value to `http://host.docker.internal:3000`.

Docker Configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R49-R60): Commented out the configuration for the `stories` service, which includes the image, build context, profiles, container name, ports, networks, and restart policy.

Removal of Unused Dockerfile:

* [`packages/stories/Dockerfile`](diffhunk://#diff-57a05c853d6125a8d93e793e6219043f43747f1f89f517fd5645f1f4c404c908L4-L15): Removed the entire Dockerfile for the `stories` package, which included steps for copying package files, installing dependencies, building the project, exposing a port, and starting the service.