### PR TITLE
Add StorageHeader, StorageList, StoragePage and Common components stories

### DIFF
--- a/packages/stories/app/stories/examples/common/Button.stories.ts
+++ b/packages/stories/app/stories/examples/common/Button.stories.ts
@@ -1,0 +1,69 @@
+import { fn } from '@storybook/test'
+import type { Meta, StoryObj } from '@storybook/react'
+import { Button } from '@/app/components'
+import { buttonsTheme } from '@/app/types'
+
+const meta = {
+  title: 'Example/Common/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    theme: {
+      control: 'select',
+      description: 'Choose your theme',
+      options: [buttonsTheme.BRIGHT, buttonsTheme.DARK]
+    },
+    size: {
+      control: 'select',
+      description: 'Choose your size',
+      options: ['small', 'medium', 'large']
+    },
+    onClick: {
+      description: 'Event occur when clicked'
+    },
+    children: {
+      control: 'text',
+      description: 'Button text'
+    }
+  },
+  args: {
+    onClick: fn(),
+    theme: buttonsTheme.BRIGHT,
+    children: '버튼'
+  }
+} satisfies Meta<typeof Button>
+
+type Story = StoryObj<typeof meta>
+
+/**
+ *
+ * The most basic form of the button shape.
+ *
+ * When used, it resizes to fit the shape of the parent component that wraps around the button.
+ *
+ */
+export const Small: Story = {
+  args: {
+    size: 'small'
+  }
+}
+
+export const Medium: Story = {
+  args: {
+    size: 'medium'
+  }
+}
+
+export const Large: Story = {
+  args: {
+    size: 'large'
+  }
+}
+
+export default meta

--- a/packages/stories/app/stories/examples/common/Modal.stories.tsx
+++ b/packages/stories/app/stories/examples/common/Modal.stories.tsx
@@ -1,0 +1,67 @@
+import { fn } from '@storybook/test'
+import type { Meta, StoryObj } from '@storybook/react'
+import { AgreementModal } from '@/app/components'
+
+const ModalContents = () => {
+  return <div style={{ padding: '2rem 0rem' }}>This is example Modal</div>
+}
+
+const meta = {
+  title: 'Example/Common/Modal',
+  component: AgreementModal,
+  parameters: {
+    viewport: {
+      layout: 'centered',
+      defaultViewport: 'tablet'
+    },
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 400
+      },
+      description: {
+        component:
+          '해당 앱의 기본적인 형태의 모달입니다. \n\n 모달의 내용에 React Component를 넣어줘서 Style의 변경이 자유롭습니다. \n\n  Yes, No 두 가지 버튼만을 가지고있으며 해당 버튼을 클릭했을 때 발생할 이벤트는 부모 컴포넌트에서 전달받습니다.'
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    title: 'Example Modal',
+    children: <ModalContents />,
+    handleAgree: fn(),
+    handleRefuse: fn()
+  }
+} satisfies Meta<typeof AgreementModal>
+
+type Story = StoryObj<typeof meta>
+
+export const Styles1Tablet: Story = {
+  args: {},
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs']
+}
+
+export const Styles2Desktop: Story = {
+  args: {},
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  }
+}
+
+export const Styles3Mobile: Story = {
+  args: {},
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  }
+}
+
+export default meta

--- a/packages/stories/app/stories/examples/common/Title.stories.tsx
+++ b/packages/stories/app/stories/examples/common/Title.stories.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import styled from 'styled-components'
+import type { Meta, StoryObj } from '@storybook/react'
+import { COLORS } from '@/app/styles'
+
+const Styled = styled.div`
+  width: 100%;
+  margin-bottom: 1.5rem;
+  font-size: 1.125rem;
+  color: ${COLORS.RED_600};
+`
+
+interface Props {
+  children: React.ReactNode
+}
+
+function Title({ children }: Props) {
+  return <Styled style={{ fontFamily: 'custom-font' }}>{children}</Styled>
+}
+
+const meta = {
+  title: 'Example/Common/Title',
+  component: Title,
+  parameters: {
+    viewport: {
+      layout: 'centered',
+      defaultViewport: 'tablet'
+    },
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 100
+      },
+      description: {
+        component: '기본 타이틀 디자인 입니다. \n\n 글꼴은 Naver D2 입니다.'
+      }
+    }
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+      description: '제목에 들어갈 텍스트를 입력하고 컴포넌트에 전달합니다.'
+    }
+  },
+  decorators: (Story) => (
+    <div>
+      <Story />
+    </div>
+  )
+} satisfies Meta<typeof Title>
+
+type Story = StoryObj<typeof meta>
+
+export const CommonTitle: Story = {
+  args: {
+    children: 'This is test title'
+  }
+}
+
+CommonTitle.parameters = {
+  viewport: {
+    defaultViewport: 'tablet'
+  }
+}
+
+export default meta

--- a/packages/stories/app/stories/examples/common/useCases/CreateCategory.stories.tsx
+++ b/packages/stories/app/stories/examples/common/useCases/CreateCategory.stories.tsx
@@ -1,0 +1,51 @@
+import { fn } from '@storybook/test'
+import type { Meta, StoryObj } from '@storybook/react'
+import { CreateCategory } from '@/app/(main)/category/components'
+import { mediaQueryStandard } from '@/app/types'
+import { COLORS } from '@/app/styles'
+
+const usecaseCatagoryButton = {
+  title: 'Example/Common/UseCases',
+  component: CreateCategory,
+  parameters: {
+    layout: 'centered',
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['!autodocs'],
+  argTypes: {},
+  args: {
+    categoryTitle: '',
+    changeValue: fn(),
+    handleSubmit: fn()
+  },
+  decorators: (Story) => (
+    <div style={{ width: '100%', height: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      <div
+        style={{
+          position: 'absolute',
+          maxWidth: mediaQueryStandard.TABLET,
+          width: '100%',
+          height: '80vh'
+        }}
+      >
+        <Story />
+        <div
+          style={{
+            height: '50%',
+            border: `1px solid ${COLORS.GRAY_200}`,
+            borderRadius: '0.25rem'
+          }}
+        />
+      </div>
+    </div>
+  )
+} satisfies Meta<typeof CreateCategory>
+
+export default usecaseCatagoryButton
+type Story = StoryObj<typeof usecaseCatagoryButton>
+
+export const UsecaseCatagoryButton: Story = {
+  args: {}
+}

--- a/packages/stories/app/stories/examples/common/useCases/CreateTodolist.stories.tsx
+++ b/packages/stories/app/stories/examples/common/useCases/CreateTodolist.stories.tsx
@@ -1,0 +1,41 @@
+import { fn } from '@storybook/test'
+import type { Meta, StoryObj } from '@storybook/react'
+import { CreateTodolist } from '@/app/(main)/todolist/components'
+import { mediaQueryStandard } from '@/app/types'
+import { COLORS } from '@/app/styles'
+
+const usecaseTodolistButton = {
+  title: 'Example/Common/UseCases',
+  component: CreateTodolist,
+  parameters: {
+    layout: 'left'
+  },
+  tags: ['!autodocs'],
+  argTypes: {},
+  decorators: (Story) => (
+    <div style={{ width: '100%', height: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+      <div
+        style={{
+          position: 'relative',
+          maxWidth: mediaQueryStandard.TABLET,
+          width: '100%',
+          height: '80vh',
+          border: `1px solid ${COLORS.GRAY_200}`,
+          borderRadius: '0.5rem'
+        }}
+      >
+        <Story handleCreateTodo={() => {}} />
+      </div>
+    </div>
+  ),
+  args: {
+    handleCreateTodo: fn()
+  }
+} satisfies Meta<typeof CreateTodolist>
+
+export default usecaseTodolistButton
+type Story = StoryObj<typeof usecaseTodolistButton>
+
+export const UsecaseTodolistButton: Story = {
+  args: {}
+}

--- a/packages/stories/app/stories/examples/storage/StorageHeader.stories.tsx
+++ b/packages/stories/app/stories/examples/storage/StorageHeader.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Container } from '@/app/components'
+import { StorageHeader, StorageSection } from '@/app/(main)/storage/components'
+import { mockCategories } from '@/app/stories/mock'
+
+const storageHeader = {
+  title: 'Example/Storage/StorageHeader',
+  component: StorageHeader,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'StorageHeader에 해당하는 컴포넌트입니다. \n\n 우측 상단의 X 버튼을 누르면 이전 투두리스트 화면으로 넘어갑니다.'
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    category: mockCategories[0]
+  },
+  decorators: (Story) => (
+    <Container>
+      <StorageSection>
+        <Story />
+      </StorageSection>
+    </Container>
+  )
+} satisfies Meta<typeof StorageHeader>
+
+export default storageHeader
+type Story = StoryObj<typeof storageHeader>
+
+/**
+ * 가장 기본적인 형태의 storageHeader 입니다.
+ */
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  args: {}
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}

--- a/packages/stories/app/stories/examples/storage/StorageList.stories.tsx
+++ b/packages/stories/app/stories/examples/storage/StorageList.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Container } from '@/app/components'
+import { StorageListDisplay, StorageSection } from '@/app/(main)/storage/components'
+import { mockStorageTodoLists } from '@/app/stories/mock'
+
+const storageList = {
+  title: 'Example/Storage/StorageList',
+  component: StorageListDisplay,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'StorageList에 해당하는 컴포넌트입니다. \n\n 완료된 투두리스트들 중 날짜별로 데이터를 구분해서 보여주는 기능입니다.'
+      }
+    }
+  },
+  argTypes: {},
+  args: {
+    list: mockStorageTodoLists
+  },
+  decorators: (Story) => (
+    <Container>
+      <StorageSection>
+        <Story />
+      </StorageSection>
+    </Container>
+  )
+} satisfies Meta<typeof StorageListDisplay>
+
+export default storageList
+type Story = StoryObj<typeof storageList>
+
+/**
+ * 가장 기본적인 형태의 storageList 입니다.
+ */
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  },
+  tags: ['autodocs'],
+  args: {}
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  },
+  tags: ['!autodocs'],
+  args: {}
+}

--- a/packages/stories/app/stories/examples/storage/pages/StoragePage.stories.tsx
+++ b/packages/stories/app/stories/examples/storage/pages/StoragePage.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Container } from '@/app/components'
+import { StorageHeader, StorageListDisplay, StorageSection } from '@/app/(main)/storage/components'
+import { mockCategories, mockStorageTodoLists } from '@/app/stories/mock'
+
+const StoragePage = {
+  title: 'Example/Storage/1. Pages',
+  component: StorageListDisplay,
+  parameters: {
+    layout: 'fullscreen',
+    tags: ['!autodocs']
+  },
+  argTypes: {},
+  args: {
+    list: mockStorageTodoLists
+  },
+  decorators: (Story) => (
+    <Container>
+      <StorageSection>
+        <StorageHeader category={mockCategories[0]} />
+        <Story />
+      </StorageSection>
+    </Container>
+  )
+} satisfies Meta<typeof StorageListDisplay>
+
+export default StoragePage
+type Story = StoryObj<typeof StoragePage>
+
+export const Styles1Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet'
+    }
+  }
+}
+
+export const Styles2Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop'
+    }
+  }
+}
+
+export const Styles3Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone14'
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds new storybook stories for various components, improving the documentation and testing capabilities for the UI components. The most important changes include the addition of stories for buttons, modals, titles, and various storage-related components.

New Storybook Stories:

* [`packages/stories/app/stories/examples/common/Button.stories.ts`](diffhunk://#diff-ff9d60d16f434aa92a0217a6dda8ace15ba85c127d2a06eb71379c2057b5859dR1-R69): Added stories for the `Button` component with different sizes and themes.
* [`packages/stories/app/stories/examples/common/Modal.stories.tsx`](diffhunk://#diff-0035c4c439db7bcb6d6ebdca2eff61dd8d817fdbabf64c476de638421fa86362R1-R67): Added stories for the `AgreementModal` component with different viewport settings.
* [`packages/stories/app/stories/examples/common/Title.stories.tsx`](diffhunk://#diff-1c581b6bd9890b0b9e10130ea1ed992e1abecd0b8fab559b5618b9a143b8ad03R1-R67): Added stories for the `Title` component with customizable text.

Storage Component Stories:

* [`packages/stories/app/stories/examples/storage/StorageHeader.stories.tsx`](diffhunk://#diff-78dcfb33fe89bb5a3c127afbf13fd2616d3c9bf02d7b57d3965b9b0581ecc298R1-R64): Added stories for the `StorageHeader` component with different viewport settings.
* [`packages/stories/app/stories/examples/storage/StorageList.stories.tsx`](diffhunk://#diff-d370b53a6c626f9c96168a40b0e31acb0e59e1e76672ac92764309353cd2b793R1-R64): Added stories for the `StorageListDisplay` component to showcase completed to-do lists by date.