### PR TITLE
Refactor Categories component and add onClickCategory prop

### DIFF
--- a/packages/client/app/(main)/category/components/Categories.tsx
+++ b/packages/client/app/(main)/category/components/Categories.tsx
@@ -8,13 +8,22 @@ interface Props {
   categories: Category[]
   openTargetModal: (category: Category) => void
   openDeleteModal: (category: Category) => void
+  onClickCategory: (id: string, isDragging: boolean) => void
 }
 
-export function Categories({ categories, openTargetModal, openDeleteModal }: Props) {
+export function Categories({ categories, openTargetModal, openDeleteModal, onClickCategory }: Props) {
   return (
     <>
       {categories.map((category) => {
-        return <CategoryItem key={category.id} category={category} openTargetModal={openTargetModal} openDeleteModal={openDeleteModal} />
+        return (
+          <CategoryItem
+            key={category.id}
+            category={category}
+            openTargetModal={openTargetModal}
+            openDeleteModal={openDeleteModal}
+            onClickCategory={onClickCategory}
+          />
+        )
       })}
     </>
   )

--- a/packages/client/app/(main)/category/components/CategoryDisplay.tsx
+++ b/packages/client/app/(main)/category/components/CategoryDisplay.tsx
@@ -27,6 +27,7 @@ export function CategoryDisplay({ categories }: Props) {
     closeModal,
     openDeleteModal,
     openTargetModal,
+    onClickCategory,
     onClickDeleteButton,
     onClickUpdateButton
   } = useCategoryModal()
@@ -39,7 +40,12 @@ export function CategoryDisplay({ categories }: Props) {
       {isModalOpen === 'delete' && ( //
         <CategoryDeleteModal closeModal={closeModal} onClickDeleteButton={onClickDeleteButton} />
       )}
-      <Categories categories={categories} openTargetModal={openTargetModal} openDeleteModal={openDeleteModal} />
+      <Categories
+        categories={categories}
+        openTargetModal={openTargetModal}
+        openDeleteModal={openDeleteModal}
+        onClickCategory={onClickCategory}
+      />
     </CategoryDisplayContainer>
   )
 }

--- a/packages/client/app/(main)/category/components/CategoryItem.tsx
+++ b/packages/client/app/(main)/category/components/CategoryItem.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useRef } from 'react'
 import styled from 'styled-components'
-import { useRouter } from 'next/navigation'
 import { FaTrashAlt } from 'react-icons/fa'
 import { IoSettings } from 'react-icons/io5'
 import { D2CodingBold } from '@/public/fonts'
@@ -90,19 +89,11 @@ interface Props {
   category: Category
   openTargetModal: (category: Category) => void
   openDeleteModal: (category: Category) => void
+  onClickCategory: (id: string, isDragging: boolean) => void
 }
 
-function CategoryComponent({ category, openDeleteModal, openTargetModal }: Props) {
-  const router = useRouter()
+function CategoryComponent({ category, openDeleteModal, openTargetModal, onClickCategory }: Props) {
   const isDragging = useRef(false)
-
-  const onClickCategory = (id: string) => {
-    if (isDragging.current) {
-      return
-    }
-
-    router.push(`/todolist/${id}`)
-  }
 
   const onCategoryDrag = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, categoryId: string) => {
     isDragging.current = false
@@ -125,7 +116,7 @@ function CategoryComponent({ category, openDeleteModal, openTargetModal }: Props
 
   return (
     <CategoryWrapper key={category.id}>
-      <CategoryButton onMouseDown={(e) => onCategoryDrag(e, category.id)} onClick={() => onClickCategory(category.id)}>
+      <CategoryButton onMouseDown={(e) => onCategoryDrag(e, category.id)} onClick={() => onClickCategory(category.id, isDragging.current)}>
         <ContentsWrapper>
           <CategoryTitle className={D2CodingBold.className}>{category.title}</CategoryTitle>
           <CategoryTime>

--- a/packages/client/app/(main)/category/hooks/useCategoryModal.ts
+++ b/packages/client/app/(main)/category/hooks/useCategoryModal.ts
@@ -48,12 +48,21 @@ export function useCategoryModal() {
     [targetCategory, closeModal, router]
   )
 
+  const onClickCategory = useCallback(
+    (id: string, isDragging: boolean) => {
+      if (isDragging) return
+      router.push(`/todolist/${id}`)
+    },
+    [router]
+  )
+
   return {
     isModalOpen,
     targetCategory,
     closeModal,
     openDeleteModal,
     openTargetModal,
+    onClickCategory,
     onClickDeleteButton,
     onClickUpdateButton
   }


### PR DESCRIPTION
This pull request introduces a new `onClickCategory` handler to the category components in the client application. The handler ensures that the category is only clicked when it is not being dragged. The most important changes include updates to the `Categories`, `CategoryDisplay`, and `CategoryItem` components, as well as modifications to the `useCategoryModal` hook.

### Updates to category components:

* [`packages/client/app/(main)/category/components/Categories.tsx`](diffhunk://#diff-6dac014dafcd35ab99d8c4938c837f58708c0fb1f611e765c01d9f8fc5498987R11-R26): Added `onClickCategory` prop to the `Props` interface and passed it to the `CategoryItem` component.
* [`packages/client/app/(main)/category/components/CategoryDisplay.tsx`](diffhunk://#diff-543d114b3152475265d08502786b49fa316c59252f0bf8a86704de9504835d42R30): Updated the `CategoryDisplay` component to include the `onClickCategory` handler from the `useCategoryModal` hook. [[1]](diffhunk://#diff-543d114b3152475265d08502786b49fa316c59252f0bf8a86704de9504835d42R30) [[2]](diffhunk://#diff-543d114b3152475265d08502786b49fa316c59252f0bf8a86704de9504835d42L42-R48)
* [`packages/client/app/(main)/category/components/CategoryItem.tsx`](diffhunk://#diff-ec93bc9f365a77372d449109e9690ad99faa6eead9ba5d55688899a6197ae532R92-L106): Modified the `CategoryItem` component to accept the `onClickCategory` prop and use it in the `CategoryButton` click event. Removed the internal `onClickCategory` function. [[1]](diffhunk://#diff-ec93bc9f365a77372d449109e9690ad99faa6eead9ba5d55688899a6197ae532R92-L106) [[2]](diffhunk://#diff-ec93bc9f365a77372d449109e9690ad99faa6eead9ba5d55688899a6197ae532L128-R119)

### Modifications to hooks:

* [`packages/client/app/(main)/category/hooks/useCategoryModal.ts`](diffhunk://#diff-5b7b649b5f8c0567a5f310a951f557cf495ceaff0279267f96ffbc0d1b3ee855R51-R65): Added the `onClickCategory` handler to the `useCategoryModal` hook, ensuring the category is only clicked when not being dragged.

### Code cleanup:

* [`packages/client/app/(main)/category/components/CategoryItem.tsx`](diffhunk://#diff-ec93bc9f365a77372d449109e9690ad99faa6eead9ba5d55688899a6197ae532L3): Removed the unused import statement for `useRouter` from the `next/navigation` package.