### PR TITLE
Refactor CreateCategory component, Add eslintrc rule, common interface

### DIFF
--- a/packages/client/.eslintrc.json
+++ b/packages/client/.eslintrc.json
@@ -54,6 +54,7 @@
     "import/no-extraneous-dependencies": 0,
     "react-hooks/rules-of-hooks": 0,
     "@typescript-eslint/no-use-before-define": 0,
+    "@typescript-eslint/return-await": 0,
     "import/no-unresolved": [
       2,
       {

--- a/packages/client/app/(main)/category/components/CreateCategory.tsx
+++ b/packages/client/app/(main)/category/components/CreateCategory.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { useRouter } from 'next/navigation'
 import { Button, Input } from '@/app/components'
-import { createCategory } from '@/app/(main)/category/api'
 import { BORDER_RADIUS_SIZES, COLORS, FONT_SIZES } from '@/app/styles'
 
 const CreateCategoryWrapper = styled.div`
@@ -29,7 +28,14 @@ const CreateError = styled.p`
   color: ${COLORS.RED_600};
 `
 
-export function CreateCategory() {
+interface Props {
+  createCategory: (title: string) => Promise<{
+    response: unknown
+    status: number
+  }>
+}
+
+export function CreateCategory({ createCategory }: Props) {
   const [categoryTitle, setCategoryTitle] = useState('')
   const [error, setError] = useState('')
 
@@ -43,10 +49,10 @@ export function CreateCategory() {
     try {
       setError('')
       setCategoryTitle('')
-      await createCategory({ title: value })
+      await createCategory(value)
       router.refresh()
     } catch (e: any) {
-      setError(JSON.parse(e.message).message)
+      setError(JSON.parse(e.message).response.message)
     }
   }
 

--- a/packages/client/app/(main)/category/components/CreateCategory.tsx
+++ b/packages/client/app/(main)/category/components/CreateCategory.tsx
@@ -29,7 +29,7 @@ const CreateError = styled.p`
 `
 
 interface Props {
-  createCategory: (title: string) => Promise<{
+  createCategory: (body: { title: string }) => Promise<{
     response: unknown
     status: number
   }>
@@ -45,11 +45,11 @@ export function CreateCategory({ createCategory }: Props) {
     setCategoryTitle(value)
   }
 
-  const handleSubmit = async (value: string) => {
+  const handleSubmit = async (title: string) => {
     try {
       setError('')
       setCategoryTitle('')
-      await createCategory(value)
+      await createCategory({ title })
       router.refresh()
     } catch (e: any) {
       setError(JSON.parse(e.message).response.message)

--- a/packages/client/app/(main)/category/page.tsx
+++ b/packages/client/app/(main)/category/page.tsx
@@ -1,15 +1,24 @@
 import { Title } from '@/app/components'
 import { CategoryDisplay, CategorySection, CreateCategory } from '@/app/(main)/category/components'
-import { getCategoryList } from '@/app/(main)/category/api'
+import { createCategory, getCategoryList } from '@/app/(main)/category/api'
 
 export default async function page() {
   const { response } = await getCategoryList()
   const { data } = response
 
+  const create = async (title: string) => {
+    'use server'
+    try {
+      return await createCategory({ title })
+    } catch (e: any) {
+      throw e
+    }
+  }
+
   return (
     <CategorySection>
       <Title>{String('Make Your Own Business To-Do List').toUpperCase()}</Title>
-      <CreateCategory />
+      <CreateCategory createCategory={create} />
       {data && <CategoryDisplay categories={data} />}
     </CategorySection>
   )

--- a/packages/client/app/types/common.ts
+++ b/packages/client/app/types/common.ts
@@ -4,3 +4,8 @@ export interface InternalError {
   response: { message: string }
   status: number
 }
+
+export interface APIResponse {
+  response: unknown
+  status: number
+}


### PR DESCRIPTION
This pull request includes several changes to the `CreateCategory` component and related files to improve error handling and type safety. The most important changes include modifying the `CreateCategory` component to accept a `createCategory` prop, updating the `page.tsx` file to pass the `createCategory` function as a prop, and adding a new `APIResponse` interface.

Changes to `CreateCategory` component:

* [`packages/client/app/(main)/category/components/CreateCategory.tsx`](diffhunk://#diff-fee51325bb1b4cf3271122a6470e9ca5efa6e4067dd875825c633dc6462d72a5L5): Modified the `CreateCategory` component to accept a `createCategory` prop and updated the `handleSubmit` function to use the `title` parameter. [[1]](diffhunk://#diff-fee51325bb1b4cf3271122a6470e9ca5efa6e4067dd875825c633dc6462d72a5L5) [[2]](diffhunk://#diff-fee51325bb1b4cf3271122a6470e9ca5efa6e4067dd875825c633dc6462d72a5L32-R38) [[3]](diffhunk://#diff-fee51325bb1b4cf3271122a6470e9ca5efa6e4067dd875825c633dc6462d72a5L42-R55)

Changes to `page.tsx`:

* [`packages/client/app/(main)/category/page.tsx`](diffhunk://#diff-72fd2ada1b433b9adbe6ca78d162a791b3ad3a3b0fe8ebb391b26f7e3b1575cdL3-R21): Updated the `page` function to pass the `createCategory` function as a prop to the `CreateCategory` component.

Type enhancements:

* [`packages/client/app/types/common.ts`](diffhunk://#diff-2edad7fabe871f9ae5846d330ada97419869ed67d585293af524850b3648743fR7-R11): Added a new `APIResponse` interface to improve type safety.

ESLint configuration:

* [`packages/client/.eslintrc.json`](diffhunk://#diff-dbbe2fad4b33cee286a676401a44d78e2bfa368423a07d7142da3a313aa9417eR57): Added a new rule to disable `@typescript-eslint/return-await`.