### PR TITLE
Refactor CategoryDisplay component and add useCategoryManage hook

### DIFF
--- a/packages/client/app/(main)/category/components/CategoryDisplay.tsx
+++ b/packages/client/app/(main)/category/components/CategoryDisplay.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Categories, CategoryDeleteModal, CategoryUpdateModal } from '@/app/(main)/category/components'
-import { useCategoryModal } from '@/app/(main)/category/hooks'
-import { Category } from '@/app/types'
+import { useCategoryManage } from '@/app/(main)/category/hooks'
+import { APIResponse, Category } from '@/app/types'
 
 const CategoryDisplayContainer = styled.div`
   overflow-y: scroll;
@@ -18,9 +18,11 @@ const CategoryDisplayContainer = styled.div`
 
 interface Props {
   categories: Category[]
+  deleteCategory: (categoryId: string) => Promise<APIResponse>
+  updateCategory: (categoryId: string, body: { title: string }) => Promise<APIResponse>
 }
 
-export function CategoryDisplay({ categories }: Props) {
+export function CategoryDisplay({ categories, deleteCategory, updateCategory }: Props) {
   const {
     isModalOpen, //
     targetCategory,
@@ -30,7 +32,7 @@ export function CategoryDisplay({ categories }: Props) {
     onClickCategory,
     onClickDeleteButton,
     onClickUpdateButton
-  } = useCategoryModal()
+  } = useCategoryManage({ deleteCategory, updateCategory })
 
   return (
     <CategoryDisplayContainer>

--- a/packages/client/app/(main)/category/hooks/index.ts
+++ b/packages/client/app/(main)/category/hooks/index.ts
@@ -1,3 +1,3 @@
 'use client'
 
-export * from './useCategoryModal'
+export * from './useCategoryManage'

--- a/packages/client/app/(main)/category/hooks/useCategoryManage.ts
+++ b/packages/client/app/(main)/category/hooks/useCategoryManage.ts
@@ -1,9 +1,13 @@
 import { useCallback, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { deleteCategory, updateCategory } from '@/app/(main)/category/api'
-import { Category } from '@/app/types'
+import { APIResponse, Category } from '@/app/types'
 
-export function useCategoryModal() {
+interface Props {
+  deleteCategory: (categoryId: string) => Promise<APIResponse>
+  updateCategory: (categoryId: string, body: { title: string }) => Promise<APIResponse>
+}
+
+export function useCategoryManage({ deleteCategory, updateCategory }: Props) {
   const router = useRouter()
   const [isModalOpen, setIsModalOpen] = useState<'delete' | 'update' | undefined>()
   const [targetCategory, setTargetCategory] = useState<Category | null>(null)
@@ -36,7 +40,7 @@ export function useCategoryModal() {
     await deleteCategory(targetCategory.id)
     closeModal()
     router.refresh()
-  }, [targetCategory, closeModal, router])
+  }, [targetCategory, closeModal, deleteCategory, router])
 
   const onClickUpdateButton = useCallback(
     async (title: string) => {
@@ -45,7 +49,7 @@ export function useCategoryModal() {
       closeModal()
       router.refresh()
     },
-    [targetCategory, closeModal, router]
+    [targetCategory, closeModal, updateCategory, router]
   )
 
   const onClickCategory = useCallback(


### PR DESCRIPTION
This pull request includes changes to the `CategoryDisplay` component and related hooks to improve category management functionality. The most important changes involve renaming a hook, updating the component to use the new hook, and modifying the hook to accept external functions for deleting and updating categories.

Changes to `CategoryDisplay` component:

* [`packages/client/app/(main)/category/components/CategoryDisplay.tsx`](diffhunk://#diff-543d114b3152475265d08502786b49fa316c59252f0bf8a86704de9504835d42L4-R5): Updated the `CategoryDisplay` component to use the `useCategoryManage` hook instead of the `useCategoryModal` hook and added `deleteCategory` and `updateCategory` props. [[1]](diffhunk://#diff-543d114b3152475265d08502786b49fa316c59252f0bf8a86704de9504835d42L4-R5) [[2]](diffhunk://#diff-543d114b3152475265d08502786b49fa316c59252f0bf8a86704de9504835d42R21-R25) [[3]](diffhunk://#diff-543d114b3152475265d08502786b49fa316c59252f0bf8a86704de9504835d42L33-R35)

Changes to hooks:

* [`packages/client/app/(main)/category/hooks/index.ts`](diffhunk://#diff-6e36970ad7428d2a3010b8e7af7bd99042173ccf137d59bc85c5e4675939ccefL3-R3): Updated the export to use `useCategoryManage` instead of `useCategoryModal`.
* [`packages/client/app/(main)/category/hooks/useCategoryManage.ts`](diffhunk://#diff-ee1e67fcb1afe31e353f751b2cf3bf81ef854a4d4f397003e4fb99ad28e2c59cL3-R10): Renamed the hook from `useCategoryModal` to `useCategoryManage` and modified it to accept `deleteCategory` and `updateCategory` functions as props. [[1]](diffhunk://#diff-ee1e67fcb1afe31e353f751b2cf3bf81ef854a4d4f397003e4fb99ad28e2c59cL3-R10) [[2]](diffhunk://#diff-ee1e67fcb1afe31e353f751b2cf3bf81ef854a4d4f397003e4fb99ad28e2c59cL39-R43) [[3]](diffhunk://#diff-ee1e67fcb1afe31e353f751b2cf3bf81ef854a4d4f397003e4fb99ad28e2c59cL48-R52)