### PR TITLE
Update TodolistDisplay component to use useTodolistManage and useTodolistModal hooks

### DIFF
--- a/packages/client/app/(main)/todolist/components/TodolistDisplay.tsx
+++ b/packages/client/app/(main)/todolist/components/TodolistDisplay.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { CreateTodolist, DraggableTodolist, TodoUpdateModal } from '@/app/(main)/todolist/components'
-import { useTodolist, useTodolistEditModal } from '@/app/(main)/todolist/hooks'
+import { useTodolistManage, useTodolistModal } from '@/app/(main)/todolist/hooks'
 import { APIResponse, CreateTodoDto, Todo, UpdateTodoDTO } from '@/app/types'
 import { SCROLL_BAR_SETTINGS, TODOLIST_HEIGHTS, COLORS } from '@/app/styles'
 
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export function TodolistDisplay({ categoryId, todolist, getTodolist, createTodolist, updateTodolist }: Props) {
-  const { list, setList, editTodo, createTodo, completeTodo } = useTodolist({
+  const { list, setList, editTodo, createTodo, completeTodo } = useTodolistManage({
     categoryId,
     todolist,
     getTodolist,
@@ -41,7 +41,7 @@ export function TodolistDisplay({ categoryId, todolist, getTodolist, createTodol
     makeUpdatedTodo,
     handleEditModalOpen,
     handleEditModalClose //
-  } = useTodolistEditModal()
+  } = useTodolistModal()
 
   return (
     <TodolistWrapper>

--- a/packages/client/app/(main)/todolist/hooks/index.ts
+++ b/packages/client/app/(main)/todolist/hooks/index.ts
@@ -1,5 +1,5 @@
 'use client'
 
 export * from './useDragDndKit'
-export * from './useTodolist'
-export * from './useTodolistEditModal'
+export * from './useTodolistModal'
+export * from './useTodolistManage'

--- a/packages/client/app/(main)/todolist/hooks/useTodolistManage.ts
+++ b/packages/client/app/(main)/todolist/hooks/useTodolistManage.ts
@@ -9,7 +9,7 @@ interface Props {
   updateTodolist: (updated: UpdateTodoDTO) => Promise<APIResponse>
 }
 
-export function useTodolist({ categoryId, todolist, getTodolist, createTodolist, updateTodolist }: Props) {
+export function useTodolistManage({ categoryId, todolist, getTodolist, createTodolist, updateTodolist }: Props) {
   const [list, setList] = useState<Todo[]>(todolist)
 
   const setNewTodolist = async () => {

--- a/packages/client/app/(main)/todolist/hooks/useTodolistModal.ts
+++ b/packages/client/app/(main)/todolist/hooks/useTodolistModal.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Todo, UpdateTodoDTO } from '@/app/types'
 
-export function useTodolistEditModal() {
+export function useTodolistModal() {
   const [modal, setModal] = useState<'edit'>()
   const [targetTodo, setTargetTodo] = useState<Todo>()
 


### PR DESCRIPTION
This pull request includes several changes to the `TodolistDisplay` component and its associated hooks in the `todolist` package. The changes primarily involve renaming hooks for better clarity and updating the imports accordingly.

Key changes include:

*Hooks Renaming for Clarity:*

* `packages/client/app/(main)/todolist/hooks/useTodolist.ts` was renamed to `useTodolistManage.ts`, and its usage was updated in `TodolistDisplay` component.
* `packages/client/app/(main)/todolist/hooks/useTodolistEditModal.ts` was renamed to `useTodolistModal.ts`, and its usage was updated in `TodolistDisplay` component.

*Import Updates:*

* Updated imports in `TodolistDisplay.tsx` to reflect the renamed hooks.
* Updated exports in `hooks/index.ts` to reflect the renamed hooks.