### PR TITLE
Fix handleCreate function in CreateTodolist component

### DIFF
--- a/packages/client/app/(main)/todolist/components/CreateTodolist.tsx
+++ b/packages/client/app/(main)/todolist/components/CreateTodolist.tsx
@@ -26,11 +26,12 @@ export function CreateTodolist({ create }: Props) {
 
   const handleCreate = useCallback(() => {
     create(title)
+    setTitle('')
   }, [create, title])
 
   return (
     <CreateTodolistWrapper>
-      <Input value={title} handleSubmit={create} changeValue={setTitle} />
+      <Input value={title} handleSubmit={handleCreate} changeValue={setTitle} />
       <Button size="medium" onClick={handleCreate}>
         POST
       </Button>


### PR DESCRIPTION
This pull request includes a small but important change to the `CreateTodolist` component in the `packages/client/app/(main)/todolist/components/CreateTodolist.tsx` file. The change ensures that the input field is cleared after creating a new to-do list item.

* [`packages/client/app/(main)/todolist/components/CreateTodolist.tsx`](diffhunk://#diff-a7891f009f3384fdfc7b57d215b96e11a976589905a40d59733e24614f11b353R29-R34): Updated the `handleCreate` function to reset the `title` state to an empty string after calling the `create` function. Also, modified the `Input` component to use `handleCreate` instead of `create` directly.