### PR TITLE
Fix import paths in TodolistHeader and TodolistSection

### DIFF
--- a/packages/ui-components/app/components/todolist/TodolistHeader.tsx
+++ b/packages/ui-components/app/components/todolist/TodolistHeader.tsx
@@ -5,8 +5,8 @@ import Link from "next/link";
 import { FaBox } from "react-icons/fa";
 import { IoClose } from "react-icons/io5";
 import { Title } from "..";
-import { changeToLocaleTime, changeToTime } from "@/app/utils";
-import { Category } from "@/app/types";
+import { changeToLocaleTime, changeToTime } from "../../utils";
+import { Category } from "../../types";
 
 interface Props {
   category: Category;

--- a/packages/ui-components/app/components/todolist/TodolistSection.tsx
+++ b/packages/ui-components/app/components/todolist/TodolistSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { COMMON_MEDIA_QUERY_STYLES } from "@/app/styles";
+import { COMMON_MEDIA_QUERY_STYLES } from "../../styles";
 
 interface Props {
   children: React.ReactNode;


### PR DESCRIPTION
This pull request includes changes to the import paths in the `TodolistHeader` and `TodolistSection` components to use relative paths instead of absolute paths.

Changes to import paths:

* [`packages/ui-components/app/components/todolist/TodolistHeader.tsx`](diffhunk://#diff-3a6a9198ff5dc60c58620965548aa543ba7b9d1f58f858b0c1d3a8aabb0f487aL8-R9): Updated import paths for `changeToLocaleTime`, `changeToTime`, and `Category` to use relative paths.
* [`packages/ui-components/app/components/todolist/TodolistSection.tsx`](diffhunk://#diff-285327b0a4cbed368fccbcdc2569c889dd278a1761e563dbab1193f06f575570L4-R4): Updated import path for `COMMON_MEDIA_QUERY_STYLES` to use a relative path.