### PR TITLE
Refactor draggable todolist and todo item components

### DIFF
--- a/packages/client/app/(main)/todolist/components/DraggableTodolist.tsx
+++ b/packages/client/app/(main)/todolist/components/DraggableTodolist.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import { DndContext } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
-import { SortableOverlay } from '@/app/components'
-import { TodoItem } from '@/app/(main)/todolist/components'
+import { TodoItem, SortableOverlay } from '@todolist/ui-components/app'
 import { useDragDndKit } from '@/app/(main)/todolist/hooks'
 import { saveTodolistOrder } from '@/app/(main)/todolist/api'
 import { Todo } from '@/app/types'
@@ -16,6 +15,7 @@ interface Props {
 
 export function DraggableTodolist({ list, setList, handleCompleteTodo, handleEditModalOpen }: Props) {
   const { activeItem, sensors, handleDragStart, handleDragEnd } = useDragDndKit<Todo>({ list, setList })
+
   return (
     <DndContext
       sensors={sensors}

--- a/packages/client/app/(main)/todolist/components/TodoItem.tsx
+++ b/packages/client/app/(main)/todolist/components/TodoItem.tsx
@@ -1,66 +1,11 @@
+'use client'
+
 import React, { memo } from 'react'
-import styled from 'styled-components'
 import { useSortable } from '@dnd-kit/sortable'
-import { CSS, Transform } from '@dnd-kit/utilities'
+import { CSS } from '@dnd-kit/utilities'
 import { CiEdit } from 'react-icons/ci'
-import { CheckCircle } from '@todolist/ui-components/app'
 import { Todo } from '@/app/types'
-import { BORDER_RADIUS_SIZES, COLORS, FONT_SIZES } from '@/app/styles'
-
-const TodoWrapper = styled.div<TodolistWrapperStylesProps>`
-  position: relative;
-  min-height: 3.375rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.75rem 1rem;
-  background-color: ${COLORS.WHITE};
-  opacity: ${({ $isDragging }) => ($isDragging ? 0.5 : 1)};
-  transform: ${({ $stringTransform }) => CSS.Translate.toString($stringTransform)};
-  transition: ${({ $transition }) => $transition};
-  border: ${({ $isDragging }) => ($isDragging ? '1px solid red' : 'none')};
-  border-bottom: ${({ $isDragging }) => ($isDragging ? '1px solid red' : `1px solid ${COLORS.GRAY_200}`)};
-  z-index: ${({ $isDragging }) => ($isDragging ? '100' : `1`)};
-  user-select: none;
-  cursor: move;
-
-  &:hover {
-    i {
-      display: block;
-    }
-  }
-`
-
-const TodoContents = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 0.875rem;
-`
-
-const TodoIcons = styled.i`
-  display: none;
-  cursor: pointer;
-
-  svg {
-    font-size: ${FONT_SIZES.xl};
-
-    &:hover {
-      background-color: ${COLORS.GRAY_200};
-    }
-
-    &:active {
-      background-color: ${COLORS.GRAY_100};
-    }
-
-    ${BORDER_RADIUS_SIZES.medium}
-  }
-`
-
-interface TodolistWrapperStylesProps {
-  $isDragging: boolean
-  $stringTransform: Transform | null
-  $transition?: string
-}
+import { CheckCircle } from '@/app/components'
 
 interface Props {
   todo: Todo
@@ -72,24 +17,38 @@ function TodoItemComponent({ todo, handleCompleteTodo, handleEditModalOpen }: Pr
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: todo.id })
 
   return (
-    <TodoWrapper
+    <div
       id={`${todo.id}-todo`}
       {...attributes}
       {...listeners}
+      className={`
+        relative min-h-[3.375rem] flex items-center justify-between py-[0.75rem] px-[1rem] bg-white
+        border-b border-${isDragging ? 'red-500' : 'gray-200'} z-[${isDragging ? 100 : 1}] select-none cursor-move
+        [&>i]:hover:block
+      `}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        transition: transition,
+        opacity: isDragging ? 0.5 : 1
+      }}
       aria-describedby={todo.id}
-      $isDragging={isDragging}
-      $stringTransform={transform}
-      $transition={transition}
       ref={setNodeRef}
     >
-      <TodoContents>
+      <div className="flex items-center gap-[0.875rem]">
         <CheckCircle onAnimationEnd={() => handleCompleteTodo(todo)} />
         <div>{todo.title}</div>
-      </TodoContents>
-      <TodoIcons>
-        <CiEdit onClick={() => handleEditModalOpen(todo)} />
-      </TodoIcons>
-    </TodoWrapper>
+      </div>
+      <i className="hidden cursor-pointer">
+        <CiEdit
+          className={`
+            text-xl rounded-md
+            hover:text-gray-400
+            active:text-gray-300
+          `}
+          onClick={() => handleEditModalOpen(todo)}
+        />
+      </i>
+    </div>
   )
 }
 


### PR DESCRIPTION
This pull request includes several updates to the `DraggableTodolist` and `TodoItem` components in the `packages/client/app/(main)/todolist` directory. The changes focus on refactoring imports, updating the `TodoItem` component to use Tailwind CSS classes instead of styled-components, and adding a missing `'use client'` directive.

Refactoring imports and dependencies:

* [`packages/client/app/(main)/todolist/components/DraggableTodolist.tsx`](diffhunk://#diff-cd19d1e4f8e552e9cb5435505ae30279f9501dac4d74f1dfc4f784bf336795b2L4-R4): Refactored imports to use `@todolist/ui-components/app` for `TodoItem` and `SortableOverlay` components.

Component updates:

* [`packages/client/app/(main)/todolist/components/TodoItem.tsx`](diffhunk://#diff-8ce7d0ef3f75a934edfbe427050d5b5dcd8b3ea7eed1d81e77dc59cc1c366fc4R1-R8): Added the `'use client'` directive at the top of the file.
* [`packages/client/app/(main)/todolist/components/TodoItem.tsx`](diffhunk://#diff-8ce7d0ef3f75a934edfbe427050d5b5dcd8b3ea7eed1d81e77dc59cc1c366fc4L75-R51): Replaced styled-components with Tailwind CSS classes for the `TodoItem` component, simplifying the code and improving consistency with other components.

Minor changes:

* [`packages/client/app/(main)/todolist/components/DraggableTodolist.tsx`](diffhunk://#diff-cd19d1e4f8e552e9cb5435505ae30279f9501dac4d74f1dfc4f784bf336795b2R18): Added a blank line for better readability.