### PR TITLE
Add SECTION_LINK_STYLES constant to TodolistHeader component, Refactor TodolistDisplay component

### DIFF
--- a/packages/client/app/(main)/todolist/components/TodolistDisplay.tsx
+++ b/packages/client/app/(main)/todolist/components/TodolistDisplay.tsx
@@ -1,24 +1,9 @@
 import React from 'react'
-import styled from 'styled-components'
+import { CreateTodolist, TodoUpdateModal, DraggableTodolist } from '@todolist/ui-components/app'
 import { useTodolistManage, useTodolistModal } from '@/app/(main)/todolist/hooks'
 import { APIResponse, CreateTodoDto, Todo, UpdateTodoDTO } from '@/app/types'
-import { SCROLL_BAR_SETTINGS, TODOLIST_HEIGHTS, COLORS } from '@/app/styles'
-import { CreateTodolist, TodoUpdateModal, DraggableTodolist } from '@todolist/ui-components/app'
+import { TODOLIST_HEIGHTS } from '@/app/styles'
 
-const TodolistWrapper = styled.div`
-  height: calc(100% - (${TODOLIST_HEIGHTS.header} + ${TODOLIST_HEIGHTS.createInput}));
-  ${SCROLL_BAR_SETTINGS};
-`
-
-const EmptyTodolist = styled.div`
-  position: relative;
-  max-height: 2.8125rem;
-  display: flex;
-  align-items: center;
-  gap: 0.875rem;
-  padding: 0.75rem 1rem;
-  color: ${COLORS.GRAY_300};
-`
 interface Props {
   categoryId: string
   todolist: Todo[]
@@ -41,7 +26,7 @@ export function TodolistDisplay({ categoryId, todolist, getTodolist, createTodol
     useTodolistModal({ editTodo })
 
   return (
-    <TodolistWrapper>
+    <div className={`h-[calc(100%-(${TODOLIST_HEIGHTS.header}+${TODOLIST_HEIGHTS.createInput}))] custom-scrollbar`}>
       <audio id="audio" src="/poped.wav"></audio>
       {modal === 'edit' && (
         <TodoUpdateModal
@@ -52,7 +37,11 @@ export function TodolistDisplay({ categoryId, todolist, getTodolist, createTodol
           handleRefuse={handleEditModalClose}
         />
       )}
-      {!list.length && <EmptyTodolist>Nothing in list 😅</EmptyTodolist>}
+      {!list.length && (
+        <div className="relative max-h-[2.8125rem] flex items-center gap-[0.875rem] py-[0.75rem] px-[1rem] text-gray-300">
+          Nothing in list 😅
+        </div>
+      )}
       <DraggableTodolist
         list={list}
         setList={setList}
@@ -61,6 +50,6 @@ export function TodolistDisplay({ categoryId, todolist, getTodolist, createTodol
         saveTodolistOrder={saveListOrder}
       />
       <CreateTodolist create={createTodo} />
-    </TodolistWrapper>
+    </div>
   )
 }

--- a/packages/ui-components/app/components/todolist/TodolistHeader.tsx
+++ b/packages/ui-components/app/components/todolist/TodolistHeader.tsx
@@ -7,6 +7,7 @@ import { IoClose } from "react-icons/io5";
 import { Title } from "..";
 import { changeToLocaleTime, changeToTime } from "../../utils";
 import { Category } from "../../types";
+import { SECTION_LINK_STYLES } from "../../styles";
 
 interface Props {
   category: Category;
@@ -20,24 +21,10 @@ export function TodolistHeader({ category }: Props) {
         <div className="text-xs">{changeToLocaleTime(category.updatedAt, changeToTime)}</div>
       </div>
       <div className="flex items-center gap-[0.75rem]">
-        <Link
-          className={`
-            w-[2.5rem] h-[2.5rem] flex justify-center items-center gap-[0.75rem] rounded-full cursor-pointer
-            hover:bg-gray-100
-            first:hover:text-red-600
-          `}
-          href={`/storage/${category.id}`}
-        >
+        <Link className={SECTION_LINK_STYLES} href={`/storage/${category.id}`}>
           <FaBox />
         </Link>
-        <Link
-          className={`
-            w-[2.5rem] h-[2.5rem] flex justify-center items-center gap-[0.75rem] rounded-full cursor-pointer
-            hover:bg-white
-            first:hover:text-red-500
-          `}
-          href={`/`}
-        >
+        <Link className={SECTION_LINK_STYLES} href={`/`}>
           <IoClose className="text-red-600" fontSize={`1.25rem`} />
         </Link>
       </div>

--- a/packages/ui-components/app/styles/button.ts
+++ b/packages/ui-components/app/styles/button.ts
@@ -24,3 +24,11 @@ export const BUTTON_SIZES_STYLES: Record<ButtonSize, string> = {
   medium: "w-fit min-w-[5rem] h-full min-h-[2.5rem] py-[1em] px-[0.6rem] text-[1rem] font-[700]",
   large: "w-fit min-w-[8rem] h-full min-h-[4rem] py-[1.2rem] px-[0.8rem] text-[1.2rem] font-[700]",
 };
+
+export const SECTION_LINK_STYLES = `
+  w-[2.5rem] h-[2.5rem] flex justify-center items-center gap-[0.75rem] rounded-full cursor-pointer
+  hover:bg-gray-100
+  active:bg-white
+  first:hover:text-red-600
+  first:active:text-red-500
+`;


### PR DESCRIPTION
This pull request includes several changes to the `TodolistDisplay` and `TodolistHeader` components, as well as updates to the styles used in these components. The most important changes involve replacing styled-components with Tailwind CSS classes and consolidating styles into a shared variable.

### Changes to `TodolistDisplay` component:
* Replaced styled-components with Tailwind CSS classes for `TodolistWrapper` and `EmptyTodolist` elements. [[1]](diffhunk://#diff-52813629e2e89fa1faae280927d499faeb5beecc70a1671d15d975ad5febde92L2-L21) [[2]](diffhunk://#diff-52813629e2e89fa1faae280927d499faeb5beecc70a1671d15d975ad5febde92L44-R29) [[3]](diffhunk://#diff-52813629e2e89fa1faae280927d499faeb5beecc70a1671d15d975ad5febde92L55-R44) [[4]](diffhunk://#diff-52813629e2e89fa1faae280927d499faeb5beecc70a1671d15d975ad5febde92L64-R53)

### Changes to `TodolistHeader` component:
* Consolidated link styles into a shared variable `SECTION_LINK_STYLES` and applied it to the `Link` components. [[1]](diffhunk://#diff-3a6a9198ff5dc60c58620965548aa543ba7b9d1f58f858b0c1d3a8aabb0f487aR10) [[2]](diffhunk://#diff-3a6a9198ff5dc60c58620965548aa543ba7b9d1f58f858b0c1d3a8aabb0f487aL23-R27)

### Styles consolidation:
* Added `SECTION_LINK_STYLES` to `button.ts` to standardize link styles across the application.