### PR TITLE
Refactor TodolistDisplay component to use dynamic height calculation

### DIFF
--- a/packages/client/app/(main)/todolist/components/TodolistDisplay.tsx
+++ b/packages/client/app/(main)/todolist/components/TodolistDisplay.tsx
@@ -26,7 +26,12 @@ export function TodolistDisplay({ categoryId, todolist, getTodolist, createTodol
     useTodolistModal({ editTodo })
 
   return (
-    <div className={`h-[calc(100%-(${TODOLIST_HEIGHTS.header}+${TODOLIST_HEIGHTS.createInput}))] custom-scrollbar`}>
+    <div
+      className="custom-scrollbar"
+      style={{
+        height: `calc(100% - (${TODOLIST_HEIGHTS.header} + ${TODOLIST_HEIGHTS.createInput}))`
+      }}
+    >
       <audio id="audio" src="/poped.wav"></audio>
       {modal === 'edit' && (
         <TodoUpdateModal


### PR DESCRIPTION
This pull request includes a small change to the `TodolistDisplay` component in `TodolistDisplay.tsx`. The change refactors the inline style for the height calculation to use a `style` attribute instead of a className for better readability and maintainability.

* [`packages/client/app/(main)/todolist/components/TodolistDisplay.tsx`](diffhunk://#diff-52813629e2e89fa1faae280927d499faeb5beecc70a1671d15d975ad5febde92L29-R34): Refactored the height calculation to use a `style` attribute instead of a className.