### PR TITLE
Add storage component and fix import in StorageHeader

### DIFF
--- a/packages/client/app/(main)/storage/[id]/page.tsx
+++ b/packages/client/app/(main)/storage/[id]/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { StorageHeader, StorageListDisplay } from '@/app/(main)/storage/components'
+import { StorageHeader } from '@todolist/ui-components/app'
+import { StorageListDisplay } from '@/app/(main)/storage/components'
 import { getCategoryById } from '@/app/(main)/category/api'
 import { getTodolistByDates } from '@/app/(main)/todolist/api'
 import { UUID } from '@/app/types'

--- a/packages/client/app/(main)/storage/components/StorageListDisplay.tsx
+++ b/packages/client/app/(main)/storage/components/StorageListDisplay.tsx
@@ -1,44 +1,7 @@
 import React from 'react'
-import styled from 'styled-components'
 import { changeToLocaleTime, changeToTime } from '@/app/utils'
 import { TodolistsBySortedDates } from '@/app/types'
-import { SCROLL_BAR_SETTINGS, COLORS, FONT_SIZES } from '@/app/styles'
 import { D2CodingLight } from '@/public/fonts'
-
-const ListWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  overflow-y: scroll;
-  ${SCROLL_BAR_SETTINGS}
-`
-
-const Contents = styled.div`
-  padding: 1rem;
-  border-bottom: 1px solid ${COLORS.GRAY_200};
-`
-
-const Date = styled.div`
-  margin-bottom: 1.125rem;
-  font-size: ${FONT_SIZES.xl};
-`
-
-const UnorderList = styled.ul`
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  padding: 0rem 1.5rem;
-`
-
-const ListItemUpdatedAt = styled.div`
-  margin-bottom: 0.25rem;
-  font-size: ${FONT_SIZES.xs};
-  color: ${COLORS.GRAY_500};
-`
-
-const ListItemTitle = styled.div`
-  font-size: ${FONT_SIZES.md};
-  color: ${COLORS.BLACK};
-`
 
 interface Props {
   list: TodolistsBySortedDates
@@ -46,22 +9,22 @@ interface Props {
 
 export function StorageListDisplay({ list }: Props) {
   return (
-    <ListWrapper>
+    <div className="flex flex-col overflow-y-scroll custom-scrollbar">
       {list.map((item) => (
-        <Contents key={item.date}>
-          <Date className={D2CodingLight.className}>{item.date}</Date>
-          <UnorderList>
+        <div className="p-[1rem] border-b border-gray-200" key={item.date}>
+          <div className={`mb-[1.125rem] text-xl ${D2CodingLight.className}`}>{item.date}</div>
+          <ul className="flex flex-col gap-[1.5rem] py-0 px-[1.5rem]">
             {item.todolists.map((todolist) => (
               <div key={todolist.id}>
-                <ListItemUpdatedAt className={D2CodingLight.className}>
+                <div className={`mb-[0.25rem] text-xs text-gray-500 ${D2CodingLight.className}`}>
                   {changeToLocaleTime(todolist.updatedAt, changeToTime)}
-                </ListItemUpdatedAt>
-                <ListItemTitle>{todolist.title}</ListItemTitle>
+                </div>
+                <div className="text-md text-black">{todolist.title}</div>
               </div>
             ))}
-          </UnorderList>
-        </Contents>
+          </ul>
+        </div>
       ))}
-    </ListWrapper>
+    </div>
   )
 }

--- a/packages/client/app/(main)/storage/layout.tsx
+++ b/packages/client/app/(main)/storage/layout.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { Container } from '@todolist/ui-components/app'
-import { StorageSection } from './components'
+import { Container, StorageSection } from '@todolist/ui-components/app'
 
 export default function layout({
   children

--- a/packages/client/app/(main)/storage/loading.tsx
+++ b/packages/client/app/(main)/storage/loading.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StorageHeader } from '@/app/(main)/storage/components'
+import { StorageHeader } from '@todolist/ui-components/app'
 
 export default function loading() {
   return (

--- a/packages/ui-components/app/components/index.ts
+++ b/packages/ui-components/app/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./category";
 export * from "./common";
+export * from "./storage";
 export * from "./todolist";

--- a/packages/ui-components/app/components/storage/StorageHeader.tsx
+++ b/packages/ui-components/app/components/storage/StorageHeader.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import Link from "next/link";
 import { IoClose } from "react-icons/io5";

--- a/packages/ui-components/app/components/storage/index.ts
+++ b/packages/ui-components/app/components/storage/index.ts
@@ -1,4 +1,2 @@
-"use client";
-
 export * from "./StorageSection";
 export * from "./StorageHeader";

--- a/packages/ui-components/app/types/todolist.ts
+++ b/packages/ui-components/app/types/todolist.ts
@@ -9,3 +9,5 @@ export interface Todo {
   updatedAt: Date;
   order: number;
 }
+
+export type TodolistsBySortedDates = { date: string; todolists: Todo[] }[];


### PR DESCRIPTION
This pull request includes several changes to the `packages/client` and `packages/ui-components` directories to improve component imports and simplify the codebase. The most important changes include updating import paths, refactoring styled-components to Tailwind CSS, and adding new exports.

### Import Path Updates:
* Updated import paths for `StorageHeader` and `StorageSection` components in `packages/client/app/(main)/storage/[id]/page.tsx`, `packages/client/app/(main)/storage/layout.tsx`, and `packages/client/app/(main)/storage/loading.tsx` to use `@todolist/ui-components/app`. ([packages/client/app/(main)/storage/[id]/page.tsxL2-R3](diffhunk://#diff-1b22f6d20454bdda35ce70b13e5d4cf2679c430746dc746576c0ed501c7edd9eL2-R3), [[1]](diffhunk://#diff-6ed144b30a7896231a0227722db727c7147f3e38497b4a28cc44850170fa51c0L2-R2) [[2]](diffhunk://#diff-f99e2b1a0145446b26fbff956030b34b01de8bfd17f13166be1121b21e459004L2-R2)

### Refactoring to Tailwind CSS:
* Refactored `StorageListDisplay` component in `packages/client/app/(main)/storage/components/StorageListDisplay.tsx` to replace styled-components with Tailwind CSS classes.

### New Exports:
* Added `storage` components to the exports in `packages/ui-components/app/components/index.ts`.
* Added `TodolistsBySortedDates` type to `packages/ui-components/app/types/todolist.ts`.

### Client Directive:
* Added `"use client";` directive to `StorageHeader` in `packages/ui-components/app/components/storage/StorageHeader.tsx` and removed it from `packages/ui-components/app/components/storage/index.ts`. [[1]](diffhunk://#diff-c1c91593a5e8093ccd6bb620446b9a9477ece9b53d22109121892d36a325687fR1-R2) [[2]](diffhunk://#diff-bffa8b161156b7e7bb81f0ecd08c55f67d49a116a859aad56a4078978e38deddL1-L2)