### PR TITLE
Refactor import paths in TodoItem component

### DIFF
--- a/packages/ui-components/app/components/todolist/TodoItem.tsx
+++ b/packages/ui-components/app/components/todolist/TodoItem.tsx
@@ -4,8 +4,8 @@ import React, { memo } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { CiEdit } from "react-icons/ci";
-import { Todo } from "@/app/types";
-import { CheckCircle } from "@/app/components";
+import { CheckCircle } from "../../";
+import { Todo } from "../../types";
 
 interface Props {
   todo: Todo;


### PR DESCRIPTION
This pull request includes changes to the import paths in the `TodoItem.tsx` component to improve module resolution and maintainability.

Changes to import paths:

* [`packages/ui-components/app/components/todolist/TodoItem.tsx`](diffhunk://#diff-76ed9b1dd690385b73dabd638a95902a6ce893eab2bf2e36d45373ace310b4e0L7-R8): Updated the import paths for `CheckCircle` and `Todo` to use relative paths instead of absolute paths.