### PR TITLE
Update category item and modal styles

### DIFF
--- a/packages/ui-components/app/components/category/CategoryItem.tsx
+++ b/packages/ui-components/app/components/category/CategoryItem.tsx
@@ -49,7 +49,7 @@ function CategoryComponent({ category, openDeleteModal, openTargetModal, onClick
         onMouseDown={(e) => onCategoryDrag(e, category.id)}
         onClick={() => onClickCategory(category.id, isDragging.current)}
       >
-        <div className="w-full h-full flex justify-between items-center pl-[0.5rem] pr-[1rem] select-none">
+        <div className="w-full h-full flex justify-between items-center pl-xs pr-md select-none">
           <h2
             className={` 
               text-sm font-[500] text-gray-500
@@ -61,7 +61,7 @@ function CategoryComponent({ category, openDeleteModal, openTargetModal, onClick
           </h2>
           <div
             className={`
-              flex gap-[0.5rem] text-xs
+              flex gap-xs text-xs
               last:text-red-600 last:font-[400]
               desktop:text-sm
           `}

--- a/packages/ui-components/app/components/category/CategoryUpdateModal.tsx
+++ b/packages/ui-components/app/components/category/CategoryUpdateModal.tsx
@@ -14,7 +14,7 @@ export function CategoryUpdateModal({ placeholder, closeModal, onClickUpdateButt
 
   return (
     <AgreementModal title="Update" handleRefuse={closeModal} handleAgree={() => onClickUpdateButton(updateTitle)}>
-      <div className="w-full flex flex-col py-[3rem] px-0 gap-[0.75rem]">
+      <div className="w-full flex flex-col py-[3rem] px-0 gap-sm">
         <div>Change Title this category</div>
         <Input
           value={updateTitle}

--- a/packages/ui-components/app/components/category/CreateCategory.tsx
+++ b/packages/ui-components/app/components/category/CreateCategory.tsx
@@ -40,7 +40,7 @@ export function CreateCategory({ createCategory }: Props) {
           +
         </Button>
       </div>
-      <div className="my-[0.5625rem]">{error}</div>
+      <div className="my-xs">{error}</div>
     </div>
   );
 }

--- a/packages/ui-components/app/components/common/AgreementModal.tsx
+++ b/packages/ui-components/app/components/common/AgreementModal.tsx
@@ -35,8 +35,8 @@ export function AgreementModal({ title, children, handleAgree, handleRefuse }: P
             <IoMdClose />
           </div>
         </div>
-        <div className="flex flex-1 py-0 px-[1.5rem] text-md border-b border-gray-200">{children}</div>
-        <div className="flex justify-end flex-1 gap-[0.75rem] p-xl">
+        <div className="flex flex-1 py-0 px-xl text-md border-b border-gray-200">{children}</div>
+        <div className="flex justify-end flex-1 gap-sm p-xl">
           <div className={`h-[2.5rem] overflow-hidden rounded-small`}>
             <Button size="medium" theme={ButtonsTheme.DARK} onClick={handleRefuse}>
               NO

--- a/packages/ui-components/app/styles/button.ts
+++ b/packages/ui-components/app/styles/button.ts
@@ -20,13 +20,13 @@ export const BUTTON_DEFAULT_STYLES: Record<ButtonsTheme, string> = {
 };
 
 export const BUTTON_SIZES_STYLES: Record<ButtonSize, string> = {
-  small: "w-fit min-w-[3rem] h-full min-h-[2rem] py-[0.8rem] px-[0.4rem] text-[0.8rem] font-[600]",
-  medium: "w-fit min-w-[5rem] h-full min-h-[2.5rem] py-[1em] px-[0.6rem] text-[1rem] font-[700]",
-  large: "w-fit min-w-[8rem] h-full min-h-[4rem] py-[1.2rem] px-[0.8rem] text-[1.2rem] font-[700]",
+  small: "w-fit min-w-[3rem] h-full min-h-[2rem] py-sm px-xs text-sm font-[600]",
+  medium: "w-fit min-w-[5rem] h-full min-h-[2.5rem] py-md px-sm text-[1rem] font-[700]",
+  large: "w-fit min-w-[8rem] h-full min-h-[4rem] py-lg px-md text-lg font-[700]",
 };
 
 export const SECTION_LINK_STYLES = `
-  w-[2.5rem] h-[2.5rem] flex justify-center items-center gap-[0.75rem] rounded-full cursor-pointer
+  w-[2.5rem] h-[2.5rem] flex justify-center items-center gap-sm rounded-full cursor-pointer
   hover:bg-gray-100
   active:bg-white
   first:hover:text-red-600


### PR DESCRIPTION
This pull request includes several changes to the `packages/ui-components` to standardize spacing and sizing classes across various components. The changes involve replacing hardcoded spacing values with predefined spacing classes.

Standardization of spacing and sizing classes:

* [`packages/ui-components/app/components/category/CategoryItem.tsx`](diffhunk://#diff-9395385389ecf86b923581bf5cba4987f5eb6cd3e48aa4fd285c640878225c2dL52-R52): Updated spacing classes from hardcoded values to predefined classes `pl-xs`, `pr-md`, and `gap-xs`. [[1]](diffhunk://#diff-9395385389ecf86b923581bf5cba4987f5eb6cd3e48aa4fd285c640878225c2dL52-R52) [[2]](diffhunk://#diff-9395385389ecf86b923581bf5cba4987f5eb6cd3e48aa4fd285c640878225c2dL64-R64)
* [`packages/ui-components/app/components/category/CategoryUpdateModal.tsx`](diffhunk://#diff-c9f276aa884bf6215a0e48479cd03e0f9250f46605cba0357ac09a840f98458dL17-R17): Replaced the hardcoded gap value with the predefined class `gap-sm`.
* [`packages/ui-components/app/components/category/CreateCategory.tsx`](diffhunk://#diff-cfaf1932f3964521cd21996841ffb3d7f53ea812fa549ffacc2078286fbb41a2L43-R43): Changed the hardcoded margin value to the predefined class `my-xs`.
* [`packages/ui-components/app/components/common/AgreementModal.tsx`](diffhunk://#diff-bb5a7ab342c70c1fe3e1cffe2e7ae80e78fb8e8deb2d3fc8afde5b80da1518cdL38-R39): Updated padding and gap values to use predefined classes `px-xl` and `gap-sm`.
* [`packages/ui-components/app/styles/button.ts`](diffhunk://#diff-f6a4767ca004a0a28b3ecbe92d5c7fec5237f9ea9fb0f8c4866af74add1cfa8aL23-R29): Standardized button size styles by replacing hardcoded values with predefined spacing classes such as `py-sm`, `px-xs`, `text-sm`, `py-md`, `px-sm`, `py-lg`, and `px-md`.