### PR TITLE
Remove unused import statements and reorganize props in Button component

### DIFF
--- a/packages/ui-components/app/components/common/AgreementModal.tsx
+++ b/packages/ui-components/app/components/common/AgreementModal.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { IoMdClose } from "react-icons/io";
 import { Button } from "../../components";

--- a/packages/ui-components/app/components/common/Button.tsx
+++ b/packages/ui-components/app/components/common/Button.tsx
@@ -4,14 +4,14 @@ import React from "react";
 import { BUTTON_DEFAULT_STYLES, BUTTON_SIZES_STYLES, ButtonsTheme, ButtonSize } from "../../styles";
 
 interface Props {
-  children?: React.ReactNode;
   size: ButtonSize;
+  children?: React.ReactNode;
   style?: React.CSSProperties;
   theme?: ButtonsTheme;
   onClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-export function Button({ children, size, style, theme = ButtonsTheme.BRIGHT, onClick, ...rest }: Props) {
+export function Button({ size, children, style, theme = ButtonsTheme.BRIGHT, onClick, ...rest }: Props) {
   return (
     <button
       className={`${BUTTON_DEFAULT_STYLES[theme]} ${BUTTON_SIZES_STYLES[size]}`}

--- a/packages/ui-components/app/components/common/Skeleton.tsx
+++ b/packages/ui-components/app/components/common/Skeleton.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 
 interface SkeletonProps {

--- a/packages/ui-components/app/components/storage/StorageHeader.tsx
+++ b/packages/ui-components/app/components/storage/StorageHeader.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import Link from "next/link";
 import { IoClose } from "react-icons/io5";

--- a/packages/ui-components/app/components/todolist/TodolistHeader.tsx
+++ b/packages/ui-components/app/components/todolist/TodolistHeader.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import Link from "next/link";
 import { FaBox } from "react-icons/fa";

--- a/packages/ui-components/app/components/todolist/TodolistSection.tsx
+++ b/packages/ui-components/app/components/todolist/TodolistSection.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { COMMON_MEDIA_QUERY_STYLES } from "../../styles";
 


### PR DESCRIPTION
This pull request includes several changes to the `packages/ui-components` directory, primarily focused on removing the "use client" directive from various component files and a minor reordering of props in the `Button` component.

### Removal of "use client" directive:

* [`packages/ui-components/app/components/common/AgreementModal.tsx`](diffhunk://#diff-bb5a7ab342c70c1fe3e1cffe2e7ae80e78fb8e8deb2d3fc8afde5b80da1518cdL1-L2): Removed "use client" directive.
* [`packages/ui-components/app/components/common/Skeleton.tsx`](diffhunk://#diff-111cebba10d4b682570c1ce2760ac1eefa7ee54775452c8cad42d6698991ddeeL1-L2): Removed "use client" directive.
* [`packages/ui-components/app/components/storage/StorageHeader.tsx`](diffhunk://#diff-c1c91593a5e8093ccd6bb620446b9a9477ece9b53d22109121892d36a325687fL1-L2): Removed "use client" directive.
* [`packages/ui-components/app/components/todolist/TodolistHeader.tsx`](diffhunk://#diff-3a6a9198ff5dc60c58620965548aa543ba7b9d1f58f858b0c1d3a8aabb0f487aL1-L2): Removed "use client" directive.
* [`packages/ui-components/app/components/todolist/TodolistSection.tsx`](diffhunk://#diff-285327b0a4cbed368fccbcdc2569c889dd278a1761e563dbab1193f06f575570L1-L2): Removed "use client" directive.

### Minor reordering of props:

* [`packages/ui-components/app/components/common/Button.tsx`](diffhunk://#diff-28619541770b76a7a9bd56596c3e2114525730c8a7a45274bed2da91e991c23dL7-R14): Reordered `children` and `size` props in the `Button` component for consistency.