### PR TITLE
Update UI component imports to use @VVSOGI package

### DIFF
--- a/packages/client/app/(main)/category/components/CategoryDisplay.tsx
+++ b/packages/client/app/(main)/category/components/CategoryDisplay.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Categories, CategoryDeleteModal, CategoryUpdateModal } from '@todolist/ui-components/app'
+import { Categories, CategoryDeleteModal, CategoryUpdateModal } from '@vvsogi/ui-components/app'
 import { useCategoryManage } from '@/app/(main)/category/hooks'
 import { APIResponse, Category } from '@/app/types'
 

--- a/packages/client/app/(main)/category/layout.tsx
+++ b/packages/client/app/(main)/category/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Container, Title, CategorySection } from '@todolist/ui-components/app'
+import { Container, Title, CategorySection } from '@vvsogi/ui-components/app'
 
 export default function layout({
   children

--- a/packages/client/app/(main)/category/loading.tsx
+++ b/packages/client/app/(main)/category/loading.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Skeleton, CreateCategory } from '@todolist/ui-components/app'
+import { Skeleton, CreateCategory } from '@vvsogi/ui-components/app'
 
 export default function HomeLoading() {
   async function mock() {

--- a/packages/client/app/(main)/category/page.tsx
+++ b/packages/client/app/(main)/category/page.tsx
@@ -1,5 +1,5 @@
 import { CategoryDisplay } from '@/app/(main)/category/components'
-import { CreateCategory } from '@todolist/ui-components/app'
+import { CreateCategory } from '@vvsogi/ui-components/app'
 import { createCategory, deleteCategory, getCategoryList, updateCategory } from '@/app/(main)/category/api'
 
 export default async function page() {

--- a/packages/client/tailwind.config.js
+++ b/packages/client/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx,mdx}',
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
-    './node_modules/@vvsogi/ui-components/app/**/*.{js,jsx,ts,tsx}' // ui-components 경로 추가
+    './node_modules/@vvsogi/ui-components/app/**/*.{js,jsx,ts,tsx}'
   ],
   theme: {
     screens: {


### PR DESCRIPTION
This pull request includes changes to update the import paths for UI components in the `category` module of the client application. The updates replace the old `@todolist/ui-components/app` path with the new `@vvsogi/ui-components/app` path.

Updates to import paths:

* [`packages/client/app/(main)/category/components/CategoryDisplay.tsx`](diffhunk://#diff-543d114b3152475265d08502786b49fa316c59252f0bf8a86704de9504835d42L2-R2): Updated import paths for `Categories`, `CategoryDeleteModal`, and `CategoryUpdateModal`.
* [`packages/client/app/(main)/category/layout.tsx`](diffhunk://#diff-f065ea7b4e7e2c23e508887856a5f9a0136f08ee6c91d72be16ef95f53ad926cL2-R2): Updated import paths for `Container`, `Title`, and `CategorySection`.
* [`packages/client/app/(main)/category/loading.tsx`](diffhunk://#diff-1f1de1afde5386c137c7fbce8ce3065f2b080547673260092f656274f116154cL3-R3): Updated import paths for `Skeleton` and `CreateCategory`.
* [`packages/client/app/(main)/category/page.tsx`](diffhunk://#diff-72fd2ada1b433b9adbe6ca78d162a791b3ad3a3b0fe8ebb391b26f7e3b1575cdL2-R2): Updated import path for `CreateCategory`.

Configuration update:

* [`packages/client/tailwind.config.js`](diffhunk://#diff-1cd61ef4ce7eb343af8650d5182a5bdabc4bd6fcf3e67345cd8266ef0305bfbaL8-R8): Removed comment from the `module.exports` configuration for Tailwind CSS.