### PR TITLE
Update start:db script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "scripts": {
     "compose-up": "docker-compose --profile infra up -d && docker-compose --profile services up -d",
+    "infra-up": "yarn workspace @todolist/server start:db",
     "client:dev": "yarn workspace @todolist/client dev",
     "server:dev": "yarn workspace @todolist/server start:dev"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,10 +8,10 @@
   "scripts": {
     "build": "npm run lint && nest build",
     "start": "nest start",
-    "start:dev": "bash ./scripts/run-infra.sh && nest start --watch",
+    "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "start:db": "bash ./scripts/run-db.sh",
+    "start:db": "bash ./scripts/run-infra.sh",
     "migration:create": "typeorm migration:create ./src/database/migration/mig",
     "migration:generate": "npm run build && typeorm migration:generate -d ./dist/database/data-source.js ./src/database/migration/mig",
     "migration:show": "typeorm migration:show -d ./dist/database/data-source.js",


### PR DESCRIPTION
This pull request includes updates to the `package.json` and `packages/server/package.json` files to improve the development workflow for the project. The most important changes involve the addition of a new script for starting the database and modifications to existing scripts for consistency.

### Development Workflow Improvements:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R11): Added a new script `infra-up` to start the database using the `@todolist/server` workspace.
* [`packages/server/package.json`](diffhunk://#diff-92fadee1dfb23b20d6b0f6557a3ea0b8a231a7591db73f9f37772383bd0575d9L11-R14): Modified the `start:dev` script to remove the dependency on `run-infra.sh` and directly start the server in watch mode.
* [`packages/server/package.json`](diffhunk://#diff-92fadee1dfb23b20d6b0f6557a3ea0b8a231a7591db73f9f37772383bd0575d9L11-R14): Changed the `start:db` script to use `run-infra.sh` instead of `run-db.sh` for better consistency with other scripts.