### PR TITLE
Add how-to-use documentation in English and Korean

### DIFF
--- a/docs/en/how-to-use.md
+++ b/docs/en/how-to-use.md
@@ -1,0 +1,31 @@
+### How to use
+
+There are two ways to use it. There is asimple way to run it with docker, and
+a way to run development mode with workspace.
+
+### Running with docker
+
+Let's start assuming you have docker and docker compose.
+
+1. cd todolist (/root)
+2. in the terminal, type "bash scripts/deploy-local.sh"
+3. from this point on, it will automatically proceed to docker.
+4. verify with "docker ps" when everything is done.
+5. container should have client, server, postgres, stories
+6. access with browser "localhost:3001"
+
+Everything is written so that you just need to run the script and it will work automatically.
+
+### Running with Workspace
+
+Workspace should have yarn.
+
+1. cd todolist (/root)
+2. type "yarn" in the terminal to install the library
+3. type "yarn infra-up" in the terminal
+4. type "yarn server:dev" in the terminal
+5. type "yarn client:dev" in the terminal
+
+This will allow you to access the basic services in development mode. We haven't written a separate command for the stories service yet, but if you want to access it as a workspace,
+
+you can type "yarn workspace @todolist/stories storybook" in the terminal.

--- a/docs/ko/how-to-use.md
+++ b/docs/ko/how-to-use.md
@@ -1,0 +1,31 @@
+### 사용법
+
+사용법은 두 가지로 나뉩니다. 도커로 간단하게 실행하는 방법이 있고,
+workspace로 개발 모드를 실행하는 방법이 있습니다.
+
+### 도커로 실행하기
+
+도커와 도커 컴포즈가 있다는 가정하에 시작하겠습니다.
+
+1. cd todolist (/root)
+2. 터미널에 "bash scripts/deploy-local.sh"
+3. 이때부터는 자동으로 도커로 진행됩니다.
+4. 모든 작업이 완료되면 "docker ps"로 확인.
+5. 컨테이너가 client, server, postgres, stories가 있어야 합니다.
+6. 브라우저 "localhost:3001"로 접근
+
+모든 과정은 스크립트만 실행하면 자동으로 동작하게 작성되어있으니 편하게 사용할 수 있습니다.
+
+### Workspace로 실행하기
+
+Workspace는 yarn이 있어야 합니다.
+
+1. cd todolist (/root)
+2. 라이브러리 설치를 위해 터미널에 "yarn" 입력
+3. 터미널에 "yarn infra-up" 입력
+4. 터미널에 "yarn server:dev" 입력
+5. 터미널에 "yarn client:dev" 입력
+
+이렇게 하면 기본적인 서비스들을 development 모드로 접근이 가능합니다.
+stories 서비스는 아직 따로 명령어를 작성하지 않았는데, 만약 workspace로 접근을 원한다면
+터미널에 "yarn workspace @todolist/stories storybook" 입력을 해주면 접근할 수 있습니다.

--- a/packages/stories/tailwind.config.js
+++ b/packages/stories/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./node_modules/@vvsogi/ui-components/app/**/*.{js,jsx,ts,tsx}",
+    "../../node_modules/@vvsogi/ui-components/app/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
     screens: {


### PR DESCRIPTION
This pull request includes updates to the documentation and configuration files to improve usability and compatibility. The most important changes include adding detailed usage instructions in both English and Korean, and updating the Tailwind CSS configuration to include an additional path.

Documentation updates:

* [`docs/en/how-to-use.md`](diffhunk://#diff-a647e6adbddb3a8f48482c117f1a7fc96c979fa41b5c60e00d6c08f7089fe407R1-R31): Added detailed instructions on how to run the application using Docker and in development mode with Workspace.
* [`docs/ko/how-to-use.md`](diffhunk://#diff-6cd02d3beeefb16a974d92e14d2c18926a9b102754a74d2044e820e3699d2b71R1-R31): Added Korean translation of the usage instructions, covering both Docker and Workspace methods.

Configuration updates:

* [`packages/stories/tailwind.config.js`](diffhunk://#diff-791a7f7e6a7e54b3cf7ed37766e4835f6f5be081ed0a651a3d0eec413571e921R9): Updated the `content` array to include an additional path for the `@vvsogi/ui-components` package.