### PR TITLE
Update DB_USERNAME in .server.example.env

### DIFF
--- a/envs/.server.example.env
+++ b/envs/.server.example.env
@@ -1,7 +1,7 @@
 DB_CONTAINER_NAME=postgres
 DB_PORT=5432
 DB_PASSWORD=something
-DB_USERNAME=user
+DB_USERNAME=benny
 DB_DATABASE=postgres
 DB_VOLUME_NAME=/var/lib/todolist
 


### PR DESCRIPTION
This pull request includes a small change to the `envs/.server.example.env` file. The change updates the database username from `user` to `benny`.

Because we are dumping the db in deploy-local.sh, the db is authorized as benny. And in this case, I need to use the username to access the db, but how to do this...

* [`envs/.server.example.env`](diffhunk://#diff-6af2f11e7f9ed8a71812f75e0eb43328418653fa6afc8940ba82f224c5381f7cL4-R4): Updated the `DB_USERNAME` value from `user` to `benny`.