### PR TITLE
Update server:dev script to use a custom run-development.sh script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "compose-up": "docker-compose --profile infra up -d && docker-compose --profile services up -d",
     "infra-up": "yarn workspace @todolist/server start:db",
     "client:dev": "docker stop frontend && yarn workspace @todolist/client dev",
-    "server:dev": "yarn workspace @todolist/server start:dev"
+    "server:dev": "docker stop backend && yarn workspace @todolist/server start:dev"
   },
   "workspaces": [
     "packages/*"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "npm run lint && nest build",
     "start": "nest start",
-    "start:dev": "nest start --watch",
+    "start:dev": "bash ./scripts/run-development.sh",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "start:db": "bash ./scripts/run-infra.sh",

--- a/packages/server/scripts/run-development.sh
+++ b/packages/server/scripts/run-development.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+
+cat ../.env.local > ../.env
+yarn nest start --watch


### PR DESCRIPTION
This pull request includes several changes to the development scripts and setup for the `@todolist/server` package. The most important changes include modifying the `server:dev` script in both the root `package.json` and the `packages/server/package.json`, and adding a new script file to handle the development environment setup.

Changes to development scripts:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R13): Updated the `server:dev` script to stop the backend Docker container before starting the server in development mode.
* [`packages/server/package.json`](diffhunk://#diff-92fadee1dfb23b20d6b0f6557a3ea0b8a231a7591db73f9f37772383bd0575d9L11-R11): Changed the `start:dev` script to execute a new shell script (`run-development.sh`) for starting the server in development mode.

New script for development environment setup:

* [`packages/server/scripts/run-development.sh`](diffhunk://#diff-6f9a5a2eea592827e97c0e02a6c382e835049038a4a7be7c68817a2e4c2b78d8R1-R6): Added a new shell script to set up the development environment by copying environment variables from `.env.local` to `.env` and starting the server with watch mode enabled.