### PR TITLE
Add Swagger documentation to the server

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.4.2",
     "@nestjs/typeorm": "^10.0.2",
     "@types/uuid": "^10.0.0",
     "dotenv": "^16.4.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@todolist/server",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "",
   "author": "",
   "private": true,

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
 import { Config } from './config'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -8,6 +9,25 @@ async function bootstrap() {
       origin: Config.client.url
     }
   })
+
+  const config = new DocumentBuilder()
+    .setTitle('Make free todolist')
+    .setDescription(
+      `A full-stack todo list application designed for practice, focusing on improving architectural skills and testing various design patterns (container-presenter, layered ...) <br /> 
+      in both frontend and backend development.
+      `
+    )
+    .setVersion('1.0')
+    .build()
+
+  const document = SwaggerModule.createDocument(app, config)
+
+  SwaggerModule.setup('api', app, document, {
+    swaggerOptions: {
+      defaultModelsExpandDepth: -1
+    }
+  })
+
   await app.listen(Config.server.port)
 }
 bootstrap()


### PR DESCRIPTION
This pull request includes several updates to the `@todolist/server` package, focusing on versioning, dependencies, and the addition of Swagger documentation. The most important changes include updating the package version, adding a new dependency, and configuring Swagger for API documentation.

Versioning and dependencies:

* [`packages/server/package.json`](diffhunk://#diff-92fadee1dfb23b20d6b0f6557a3ea0b8a231a7591db73f9f37772383bd0575d9L3-R3): Updated the package version from `0.0.1` to `1.0.0`.
* [`packages/server/package.json`](diffhunk://#diff-92fadee1dfb23b20d6b0f6557a3ea0b8a231a7591db73f9f37772383bd0575d9R33): Added `@nestjs/swagger` version `^7.4.2` to the dependencies.

Swagger documentation:

* [`packages/server/src/main.ts`](diffhunk://#diff-e305b10e38f50f6cfe9754416f95004a2b0b53da8c51b8a06fa7cc4ed78aab4aR4-R30): Imported `DocumentBuilder` and `SwaggerModule` from `@nestjs/swagger`.
* [`packages/server/src/main.ts`](diffhunk://#diff-e305b10e38f50f6cfe9754416f95004a2b0b53da8c51b8a06fa7cc4ed78aab4aR4-R30): Configured Swagger with a title, description, version, and setup for the API documentation.