### PR TITLE
Add Swagger decorators to CategoryController

### DIFF
--- a/packages/server/src/services/category/category.controller.ts
+++ b/packages/server/src/services/category/category.controller.ts
@@ -12,6 +12,7 @@ import {
 } from './types'
 import { ValidateCreateDTO, ValidateDeletedCheckedDTO, ValidateUpdateDTO } from './decorator'
 import { ValidateIdParamDTO } from '../common'
+import { SwaggerCreateCategory } from './decorator/swagger/createCategory.swagger'
 
 @ApiTags('Category')
 @Controller('category')
@@ -19,6 +20,7 @@ export class CategoryController {
   constructor(private categoryService: CategoryService) {}
 
   @Post()
+  @SwaggerCreateCategory()
   async createCategory(@ValidateCreateDTO() createCategoryDto: CreateCategoryDto): Promise<DefaultCategoryResponseType> {
     const { title } = createCategoryDto
     return this.categoryService.createCategory(title)

--- a/packages/server/src/services/category/category.controller.ts
+++ b/packages/server/src/services/category/category.controller.ts
@@ -10,9 +10,15 @@ import {
   UpdateCategoryDto,
   UpdateCategoryResponseType
 } from './types'
-import { ValidateCreateDTO, ValidateDeletedCheckedDTO, ValidateUpdateDTO } from './decorator'
+import {
+  ValidateCreateDTO,
+  ValidateDeletedCheckedDTO,
+  ValidateUpdateDTO,
+  SwaggerCreateCategory,
+  SwaggerGetCategory,
+  SwaggerGetCategoryById
+} from './decorator'
 import { ValidateIdParamDTO } from '../common'
-import { SwaggerCreateCategory } from './decorator/swagger/createCategory.swagger'
 
 @ApiTags('Category')
 @Controller('category')
@@ -27,11 +33,13 @@ export class CategoryController {
   }
 
   @Get()
+  @SwaggerGetCategory()
   async getCategories(@ValidateDeletedCheckedDTO() categoryDeleteParamsDto: CategoryDeleteParamsDto): Promise<GetCategoriesResponseType> {
     return this.categoryService.getCategories(categoryDeleteParamsDto)
   }
 
   @Get(':categoryId')
+  @SwaggerGetCategoryById()
   async getCategoryById(@ValidateIdParamDTO() getCategoryDto: CategoryIdParamsDto): Promise<DefaultCategoryResponseType> {
     const { categoryId } = getCategoryDto
     return this.categoryService.getCategoryById(categoryId)

--- a/packages/server/src/services/category/decorator/index.ts
+++ b/packages/server/src/services/category/decorator/index.ts
@@ -1,3 +1,5 @@
+export * from './swagger'
+
 export * from './createCategory.decorator'
 export * from './validator'
 export * from './deletedCheck.decorator'

--- a/packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts
+++ b/packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common'
-import { ApiBody, ApiProperty } from '@nestjs/swagger'
+import { ApiBody, ApiProperty, ApiResponse } from '@nestjs/swagger'
 
 class CreateCategory {
   @ApiProperty({
@@ -7,7 +7,6 @@ class CreateCategory {
     description: `Decide on a title for the category you want to create`
   })
   title: string
-  description: string
 }
 
 export function SwaggerCreateCategory() {
@@ -19,44 +18,53 @@ export function SwaggerCreateCategory() {
 You must attach a title to the body as a required DTO.
 
 ## If you sent invalid type data [400 ERROR]
-    POST 
-        {
-            title: 1000,
-        }
+POST 
 
-    Response
-        {
-            "message": "Received unexpected data 'title' [INVALID TYPE ERROR]",
-            "error": "Bad Request",
-            "statusCode": 400
-        }
+    {
+        title: 1000,
+    }
+
+Response
+
+    {
+        "message": "Received unexpected data 'title' [INVALID TYPE ERROR]",
+        "error": "Bad Request",
+        "statusCode": 400
+    }
 
 ## If you sent less than three characters [400 ERROR]
-    POST 
-        {
-            title: "",
-        }
+POST 
 
-    Response
-        {
-            "message": "You must enter at least three characters. [WRONG DATA SENT ERROR]",
-            "error": "Bad Request",
-            "statusCode": 400
-        }
+    {
+        title: "",
+    }
+
+Response
+
+    {
+        "message": "You must enter at least three characters. [WRONG DATA SENT ERROR]",
+        "error": "Bad Request",
+        "statusCode": 400
+    }
 
 ## If you sent missing data [404 ERROR]
-    POST 
-        { NOTHING }
 
-    Response
-        {
-            "message": "Received unexpected data 'title' [MISSING DATA ERROR]",
-            "error": "Not Found",
-            "statusCode": 404
-        }
+POST 
 
-        
-      `
+    { NOTHING }
+
+Response
+
+    {
+        "message": "Received unexpected data 'title' [MISSING DATA ERROR]",
+        "error": "Not Found",
+        "statusCode": 404
+    }
+`
+    }),
+    ApiResponse({
+      status: 201,
+      description: 'success'
     })
   )
 }

--- a/packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts
+++ b/packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts
@@ -17,6 +17,16 @@ export function SwaggerCreateCategory() {
 ## POST API for creating a category.
 You must attach a title to the body as a required DTO.
 
+## Success case [201 status code]
+
+    {
+        "id": "UUID",
+        "title": "Test title",
+        "createdAt": "2025-02-10T13:00:27.440Z",
+        "updatedAt": "2025-02-10T13:00:27.440Z",
+        "deleted": false
+    }
+
 ## If you sent invalid type data [400 ERROR]
 POST 
 

--- a/packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts
+++ b/packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts
@@ -1,0 +1,62 @@
+import { applyDecorators } from '@nestjs/common'
+import { ApiBody, ApiProperty } from '@nestjs/swagger'
+
+class CreateCategory {
+  @ApiProperty({
+    example: `Test title`,
+    description: `Decide on a title for the category you want to create`
+  })
+  title: string
+  description: string
+}
+
+export function SwaggerCreateCategory() {
+  return applyDecorators(
+    ApiBody({
+      type: CreateCategory,
+      description: `
+## POST API for creating a category.
+You must attach a title to the body as a required DTO.
+
+## If you sent invalid type data [400 ERROR]
+    POST 
+        {
+            title: 1000,
+        }
+
+    Response
+        {
+            "message": "Received unexpected data 'title' [INVALID TYPE ERROR]",
+            "error": "Bad Request",
+            "statusCode": 400
+        }
+
+## If you sent less than three characters [400 ERROR]
+    POST 
+        {
+            title: "",
+        }
+
+    Response
+        {
+            "message": "You must enter at least three characters. [WRONG DATA SENT ERROR]",
+            "error": "Bad Request",
+            "statusCode": 400
+        }
+
+## If you sent missing data [404 ERROR]
+    POST 
+        { NOTHING }
+
+    Response
+        {
+            "message": "Received unexpected data 'title' [MISSING DATA ERROR]",
+            "error": "Not Found",
+            "statusCode": 404
+        }
+
+        
+      `
+    })
+  )
+}

--- a/packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts
+++ b/packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts
@@ -17,7 +17,7 @@ export function SwaggerCreateCategory() {
 ## POST API for creating a category.
 You must attach a title to the body as a required DTO.
 
-## Success case [201 status code]
+### Success case [201 status code]
 
     {
         "id": "UUID",
@@ -27,7 +27,7 @@ You must attach a title to the body as a required DTO.
         "deleted": false
     }
 
-## If you sent invalid type data [400 ERROR]
+### If you sent invalid type data [400 ERROR]
 POST 
 
     {
@@ -42,7 +42,7 @@ Response
         "statusCode": 400
     }
 
-## If you sent less than three characters [400 ERROR]
+### If you sent less than three characters [400 ERROR]
 POST 
 
     {
@@ -57,7 +57,7 @@ Response
         "statusCode": 400
     }
 
-## If you sent missing data [404 ERROR]
+### If you sent missing data [404 ERROR]
 
 POST 
 

--- a/packages/server/src/services/category/decorator/swagger/getCategory.swagger.ts
+++ b/packages/server/src/services/category/decorator/swagger/getCategory.swagger.ts
@@ -1,0 +1,44 @@
+import { applyDecorators } from '@nestjs/common'
+import { ApiQuery, ApiResponse } from '@nestjs/swagger'
+
+export function SwaggerGetCategory() {
+  return applyDecorators(
+    ApiQuery({
+      name: 'deleted',
+      schema: {
+        type: 'boolean',
+        default: false
+      },
+      description: `
+## GET API get all category Based on the query.
+if you don't enter a query, it will automatically request false.
+
+### Success case [200 status code]
+
+    {
+        "data": [
+            {
+                "id": "16874008-8915-4d53-9239-3913f7ee2089",
+                "title": "Test title",
+                "createdAt": "2025-02-10T13:00:27.440Z",
+                "updatedAt": "2025-02-10T13:00:27.440Z",
+                "deleted": false
+            },
+            {
+                "id": "a1b0b12f-a010-4a40-ae96-519d070a3a3a",
+                "title": "Test title",
+                "createdAt": "2025-02-10T12:29:24.504Z",
+                "updatedAt": "2025-02-10T12:29:24.504Z",
+                "deleted": false
+            } ...
+        ],
+        "total": n
+    }
+`
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'success'
+    })
+  )
+}

--- a/packages/server/src/services/category/decorator/swagger/getCategoryById.swagger.ts
+++ b/packages/server/src/services/category/decorator/swagger/getCategoryById.swagger.ts
@@ -1,0 +1,47 @@
+import { applyDecorators } from '@nestjs/common'
+import { ApiParam, ApiResponse } from '@nestjs/swagger'
+
+export function SwaggerGetCategoryById() {
+  return applyDecorators(
+    ApiParam({
+      name: 'categoryId',
+      schema: {
+        type: 'string',
+        default: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3'
+      },
+      description: `
+## GET API for get a category by id.
+
+### Success case [200 status code]
+
+    {
+      "id": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+      "title": "Testing update",
+      "createdAt": "2024-12-17T08:44:48.925Z",
+      "updatedAt": "2025-02-02T23:46:54.263Z",
+      "deleted": false
+    }
+
+### If doesn't exist data [404 ERROR]
+
+    {
+      "message": "Received unmatched data 'categoryId' [INVALID UUID TYPE ERROR]",
+      "error": "Bad Request",
+      "statusCode": 400
+    }
+
+### If sent invalid data type [400 ERROR]
+
+    {
+      "message": "Received unmatched data 'categoryId' [INVALID UUID TYPE ERROR]",
+      "error": "Bad Request",
+      "statusCode": 400
+    }
+`
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'success'
+    })
+  )
+}

--- a/packages/server/src/services/category/decorator/swagger/index.ts
+++ b/packages/server/src/services/category/decorator/swagger/index.ts
@@ -1,0 +1,3 @@
+export * from './createCategory.swagger'
+export * from './getCategory.swagger'
+export * from './getCategoryById.swagger'


### PR DESCRIPTION
This pull request introduces Swagger decorators to the `CategoryController` to improve API documentation and validation. The changes include adding new decorators for creating, retrieving, and retrieving by ID categories, as well as updating the imports and exports accordingly.

Enhancements to API documentation and validation:

* [`packages/server/src/services/category/category.controller.ts`](diffhunk://#diff-1664ad043f2659061e21aaa2434e3fd366e45349893a416d8925421c5e93269dL13-R20): Added Swagger decorators `SwaggerCreateCategory`, `SwaggerGetCategory`, and `SwaggerGetCategoryById` to the respective endpoints to enhance API documentation. [[1]](diffhunk://#diff-1664ad043f2659061e21aaa2434e3fd366e45349893a416d8925421c5e93269dL13-R20) [[2]](diffhunk://#diff-1664ad043f2659061e21aaa2434e3fd366e45349893a416d8925421c5e93269dR29-R42)
* [`packages/server/src/services/category/decorator/index.ts`](diffhunk://#diff-67b53d530f54658330135e890385a8f8eddb2a99a5a96d38960fc25810ec8f92R1-R2): Exported all Swagger decorators to make them available for use in other parts of the application.
* [`packages/server/src/services/category/decorator/swagger/createCategory.swagger.ts`](diffhunk://#diff-2ae4e4e21dd85d3a22b155868a066d94227e9a29218ef233eb4183cad020f741R1-R80): Implemented `SwaggerCreateCategory` decorator to document the POST API for creating a category, including success and error responses.
* [`packages/server/src/services/category/decorator/swagger/getCategory.swagger.ts`](diffhunk://#diff-58a160bdc6666e721836ca2c57c5d66fe97fd469dbef3282753d0f3bca1e6f94R1-R44): Implemented `SwaggerGetCategory` decorator to document the GET API for retrieving categories based on query parameters, including success responses.
* [`packages/server/src/services/category/decorator/swagger/getCategoryById.swagger.ts`](diffhunk://#diff-a73960448d451576447f33f2adb18785847976c5f89d1de4f9d01e5c7db51fc8R1-R47): Implemented `SwaggerGetCategoryById` decorator to document the GET API for retrieving a category by ID, including success and error responses.