### PR TITLE
Add SwaggerUpdateCategory decorator to updateCategory method

### DIFF
--- a/packages/server/src/services/category/category.controller.ts
+++ b/packages/server/src/services/category/category.controller.ts
@@ -16,7 +16,8 @@ import {
   ValidateUpdateDTO,
   SwaggerCreateCategory,
   SwaggerGetCategory,
-  SwaggerGetCategoryById
+  SwaggerGetCategoryById,
+  SwaggerUpdateCategory
 } from './decorator'
 import { ValidateIdParamDTO } from '../common'
 
@@ -46,6 +47,7 @@ export class CategoryController {
   }
 
   @Patch(':categoryId')
+  @SwaggerUpdateCategory()
   async updateCategory(
     @ValidateIdParamDTO() idParamsDto: CategoryIdParamsDto,
     @ValidateUpdateDTO() updateCategoryDto: UpdateCategoryDto

--- a/packages/server/src/services/category/decorator/swagger/index.ts
+++ b/packages/server/src/services/category/decorator/swagger/index.ts
@@ -1,3 +1,4 @@
 export * from './createCategory.swagger'
 export * from './getCategory.swagger'
 export * from './getCategoryById.swagger'
+export * from './updateCategory.swagger'

--- a/packages/server/src/services/category/decorator/swagger/updateCategory.swagger.ts
+++ b/packages/server/src/services/category/decorator/swagger/updateCategory.swagger.ts
@@ -1,0 +1,83 @@
+import { applyDecorators } from '@nestjs/common'
+import { ApiBody, ApiParam, ApiResponse } from '@nestjs/swagger'
+
+export function SwaggerUpdateCategory() {
+  return applyDecorators(
+    ApiParam({
+      name: 'categoryId',
+      schema: {
+        type: 'string',
+        default: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3'
+      },
+      description: `
+## GET API for get a category by id.
+
+### Success case [200 status code]
+
+    {
+      "id": "f144cc78-34d9-4d0a-9e95-48cf7102dce3",
+      "title": "update title",
+      "createdAt": "2024-12-17T08:44:48.925Z",
+      "updatedAt": "2025-02-10T04:34:17.832Z",
+      "deleted": false
+    }
+
+### If doesn't exist data [404 ERROR]
+
+    {
+      "message": "Received unmatched data 'categoryId' [INVALID UUID TYPE ERROR]",
+      "error": "Bad Request",
+      "statusCode": 400
+    }
+
+### If sent invalid data type [400 ERROR]
+
+    {
+      "message": "Received unmatched data 'categoryId' [INVALID UUID TYPE ERROR]",
+      "error": "Bad Request",
+      "statusCode": 400
+    }
+
+### If you sent invalid type data [400 ERROR]
+
+    {
+        "message": "Received unexpected data 'title' [INVALID TYPE ERROR]",
+        "error": "Bad Request",
+        "statusCode": 400
+    }
+
+### If you sent less than three characters [400 ERROR]
+
+    {
+        "message": "You must enter at least three characters. [WRONG DATA SENT ERROR]",
+        "error": "Bad Request",
+        "statusCode": 400
+    }
+
+### If you sent missing data [404 ERROR]
+
+    {
+        "message": "Received unexpected data 'title' [MISSING DATA ERROR]",
+        "error": "Not Found",
+        "statusCode": 404
+    }
+`
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Write contents to target that update category you want',
+            example: 'update title'
+          }
+        }
+      }
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'success'
+    })
+  )
+}


### PR DESCRIPTION
This pull request introduces a new Swagger decorator for the update category endpoint in the `CategoryController`. The most important changes include adding the `SwaggerUpdateCategory` decorator, updating the import statements, and exporting the new decorator.

Changes to `CategoryController`:

* Added `SwaggerUpdateCategory` decorator to the `updateCategory` method in `CategoryController` (`packages/server/src/services/category/category.controller.ts`).

Updates to imports and exports:

* Updated import statements in `CategoryController` to include `SwaggerUpdateCategory` (`packages/server/src/services/category/category.controller.ts`).
* Added export for `SwaggerUpdateCategory` in the `swagger` index file (`packages/server/src/services/category/decorator/swagger/index.ts`).

New Swagger decorator:

* Created `SwaggerUpdateCategory` decorator to document the `updateCategory` endpoint, including parameter, body, and response details (`packages/server/src/services/category/decorator/swagger/updateCategory.swagger.ts`).