### PR TITLE
Add DocsGetCategory decorator to getCategories method

### DIFF
--- a/packages/server/src/common/decorator/api-docs.decorator.ts
+++ b/packages/server/src/common/decorator/api-docs.decorator.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { EndpointDecoratorMetadata } from '..'
 
-export const ApiDocsEndpoint = (metadata: EndpointDecoratorMetadata): MethodDecorator => {
+export const ApiDocsEndpoint = (metadata: EndpointDecoratorMetadata<any>): MethodDecorator => {
   return (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
     Reflect.defineMetadata('api:endpoint', metadata, target, propertyKey)
     return descriptor

--- a/packages/server/src/common/types/api-docs.type.ts
+++ b/packages/server/src/common/types/api-docs.type.ts
@@ -10,7 +10,7 @@ export interface ApiProperty {
 }
 
 export interface ApiParameters {
-  type: 'object'
+  type: string
   properties: Record<string, ApiProperty>
   required?: string[]
 }
@@ -74,29 +74,35 @@ export interface ApiDocumentation {
   controllers: ApiController[]
 }
 
-export interface EndpointDecoratorMetadata {
+type MetadataPropertiesKeys = 'body' | 'query' | 'params' | 'response'
+
+export type DefaultMetadataProperties = {
+  [P in MetadataPropertiesKeys]?: string
+}
+
+export interface EndpointDecoratorMetadata<P extends DefaultMetadataProperties> {
   description: string
   request?: {
     body?: {
       type: string
-      properties: Record<string, ApiProperty>
+      properties: P['body'] extends string ? Record<P['body'], ApiProperty> : never
       required?: string[]
     }
     query?: {
       type: string
-      properties: Record<string, ApiProperty>
+      properties: P['query'] extends string ? Record<P['query'], ApiProperty> : never
       required?: string[]
     }
     params?: {
       type: string
-      properties: Record<string, ApiProperty>
+      properties: P['params'] extends string ? Record<P['params'], ApiProperty> : never
       required?: string[]
     }
   }
   response?: {
     type: string
-    properties?: Record<string, ApiProperty>
-    example?: any
+    properties?: P['response'] extends string ? Record<P['response'], ApiProperty> : never
+    example?: P['response'] extends string ? Record<P['response'], any> : never
   }
   deprecated?: boolean
   tags?: string[]

--- a/packages/server/src/services/category/category.controller.ts
+++ b/packages/server/src/services/category/category.controller.ts
@@ -20,7 +20,8 @@ import {
   SwaggerGetCategoryById,
   SwaggerUpdateCategory,
   SwaggerDeleteCategory,
-  DocsCreateCategory
+  DocsCreateCategory,
+  DocsGetCategory
 } from './decorator'
 import { ValidateIdParamDTO } from '../common'
 
@@ -42,6 +43,7 @@ export class CategoryController {
   }
 
   @Get()
+  @DocsGetCategory()
   @SwaggerGetCategory()
   async getCategories(@ValidateDeletedCheckedDTO() categoryDeleteParamsDto: CategoryDeleteParamsDto): Promise<GetCategoriesResponseType> {
     return this.categoryService.getCategories(categoryDeleteParamsDto)

--- a/packages/server/src/services/category/decorator/custom-docs/get-category.decorator.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/get-category.decorator.ts
@@ -1,21 +1,20 @@
 import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'src/common'
 
-export const DocsCreateCategory = () => {
+export const DocsGetCategory = () => {
   const metadata: EndpointDecoratorMetadata<{
-    body: 'title'
-    response: 'id' | 'title' | 'createdAt' | 'updatedAt'
+    query: 'deleted'
+    response: 'id' | 'title' | 'createdAt' | 'updatedAt' | 'deleted'
   }> = {
-    description: 'Create a new category',
+    description: '',
     request: {
-      body: {
-        type: 'object',
+      query: {
+        type: 'boolean',
         properties: {
-          title: {
-            type: 'string',
-            description: '카테고리 제목'
+          deleted: {
+            type: 'boolean',
+            description: `Get all category Based on the query.`
           }
-        },
-        required: ['title']
+        }
       }
     },
     response: {
@@ -36,13 +35,18 @@ export const DocsCreateCategory = () => {
         updatedAt: {
           type: 'string',
           description: '수정 일시'
+        },
+        deleted: {
+          type: 'boolean',
+          description: '삭제된 카테고리 분별'
         }
       },
       example: {
-        id: 'uuid-example',
-        title: '새로운 카테고리',
-        createdAt: '2024-02-12T00:00:00.000Z',
-        updatedAt: '2024-02-12T00:00:00.000Z'
+        id: '16874008-8915-4d53-9239-3913f7ee2089',
+        title: 'Test title',
+        createdAt: '2025-02-10T13:00:27.440Z',
+        updatedAt: '2025-02-10T13:00:27.440Z',
+        deleted: false
       }
     }
   }

--- a/packages/server/src/services/category/decorator/custom-docs/index.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/index.ts
@@ -1,1 +1,2 @@
 export * from './create-category.decorator'
+export * from './get-category.decorator'


### PR DESCRIPTION
This pull request includes several changes to improve the API documentation and add new decorators for the category service. The most important changes include updating the `EndpointDecoratorMetadata` type, adding a new decorator for fetching categories, and modifying existing decorators to use the updated metadata type.

Improvements to API documentation:

* [`packages/server/src/common/decorator/api-docs.decorator.ts`](diffhunk://#diff-008d6cd96599672e4ea24de6332eee07ccf5659998d3101f8b9c604a0e6a4756L4-R4): Updated `ApiDocsEndpoint` to use a generic `EndpointDecoratorMetadata` type.
* [`packages/server/src/common/types/api-docs.type.ts`](diffhunk://#diff-f424573d1651dc6578e317ae0f3d479baee0f072ed91efcc3f99615485673c7eL13-R13): Updated `ApiParameters` to use a string type and modified `EndpointDecoratorMetadata` to use generic properties for `body`, `query`, `params`, and `response`. [[1]](diffhunk://#diff-f424573d1651dc6578e317ae0f3d479baee0f072ed91efcc3f99615485673c7eL13-R13) [[2]](diffhunk://#diff-f424573d1651dc6578e317ae0f3d479baee0f072ed91efcc3f99615485673c7eL77-R105)

New and updated decorators:

* [`packages/server/src/services/category/category.controller.ts`](diffhunk://#diff-1664ad043f2659061e21aaa2434e3fd366e45349893a416d8925421c5e93269dL23-R24): Added `DocsGetCategory` decorator to the `getCategories` method. [[1]](diffhunk://#diff-1664ad043f2659061e21aaa2434e3fd366e45349893a416d8925421c5e93269dL23-R24) [[2]](diffhunk://#diff-1664ad043f2659061e21aaa2434e3fd366e45349893a416d8925421c5e93269dR46)
* [`packages/server/src/services/category/decorator/custom-docs/create-category.decorator.ts`](diffhunk://#diff-fb3b6734ade3b3818c09eb5e1cfc4c5511860ce31391bb9c70d7fc8aa8105af0L4-R7): Updated `DocsCreateCategory` to use the new generic `EndpointDecoratorMetadata` type. [[1]](diffhunk://#diff-fb3b6734ade3b3818c09eb5e1cfc4c5511860ce31391bb9c70d7fc8aa8105af0L4-R7) [[2]](diffhunk://#diff-fb3b6734ade3b3818c09eb5e1cfc4c5511860ce31391bb9c70d7fc8aa8105af0L19-R22)
* [`packages/server/src/services/category/decorator/custom-docs/get-category.decorator.ts`](diffhunk://#diff-1f59528e38c76e97302c340c5540196ad049e86ba66927c27d464b8057f16fd0R1-R55): Added new `DocsGetCategory` decorator for fetching categories with metadata.
* [`packages/server/src/services/category/decorator/custom-docs/index.ts`](diffhunk://#diff-c75451c74517d98f77f94159216394ff5ac1f78e9d6667efbe72da2cd9fd1644R2): Exported the new `DocsGetCategory` decorator.