### PR TITLE
Add custom documentation decorator for getting category by ID and update other things.

### DIFF
--- a/packages/server/src/common/types/api-docs.type.ts
+++ b/packages/server/src/common/types/api-docs.type.ts
@@ -102,7 +102,9 @@ export interface EndpointDecoratorMetadata<P extends DefaultMetadataProperties> 
   response?: {
     type: string
     properties?: P['response'] extends string ? Record<P['response'], ApiProperty> : never
-    example?: P['response'] extends string ? Record<P['response'], any> : never
+    example?: P['response'] extends string
+      ? Record<P['response'], any> | Array<Record<P['response'], any>> //
+      : never
   }
   deprecated?: boolean
   tags?: string[]

--- a/packages/server/src/services/category/decorator/custom-docs/create-category.decorator.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/create-category.decorator.ts
@@ -3,7 +3,7 @@ import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'src/common'
 export const DocsCreateCategory = () => {
   const metadata: EndpointDecoratorMetadata<{
     body: 'title'
-    response: 'id' | 'title' | 'createdAt' | 'updatedAt'
+    response: 'id' | 'title' | 'createdAt' | 'updatedAt' | 'deleted'
   }> = {
     description: 'Create a new category',
     request: {
@@ -23,26 +23,31 @@ export const DocsCreateCategory = () => {
       properties: {
         id: {
           type: 'string',
-          description: '카테고리 ID'
+          description: 'Created category ID'
         },
         title: {
           type: 'string',
-          description: '카테고리 제목'
+          description: 'Created category title'
         },
         createdAt: {
           type: 'string',
-          description: '생성 일시'
+          description: 'Created category createdAt'
         },
         updatedAt: {
           type: 'string',
-          description: '수정 일시'
+          description: 'Created category updatedAt'
+        },
+        deleted: {
+          type: 'boolean',
+          description: 'Created category deleted'
         }
       },
       example: {
-        id: 'uuid-example',
-        title: '새로운 카테고리',
-        createdAt: '2024-02-12T00:00:00.000Z',
-        updatedAt: '2024-02-12T00:00:00.000Z'
+        id: '98874008-8915-4d53-9239-3913f7ee2089',
+        title: 'Test title',
+        createdAt: '2025-02-10T13:00:27.440Z',
+        updatedAt: '2025-02-10T13:00:27.440Z',
+        deleted: false
       }
     }
   }

--- a/packages/server/src/services/category/decorator/custom-docs/get-category-by-id.decorator.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/get-category-by-id.decorator.ts
@@ -1,0 +1,55 @@
+import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'src/common'
+
+export const DocsGetCategoryById = () => {
+  const metadata: EndpointDecoratorMetadata<{
+    params: 'categoryId'
+    response: 'id' | 'title' | 'createdAt' | 'updatedAt' | 'deleted'
+  }> = {
+    description: '',
+    request: {
+      params: {
+        type: 'string',
+        properties: {
+          categoryId: {
+            type: 'string',
+            description: 'Target category Id that you find'
+          }
+        }
+      }
+    },
+    response: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Found category ID'
+        },
+        title: {
+          type: 'string',
+          description: 'Found category title'
+        },
+        createdAt: {
+          type: 'string',
+          description: 'Found category createdAt'
+        },
+        updatedAt: {
+          type: 'string',
+          description: 'Found category updatedAt'
+        },
+        deleted: {
+          type: 'boolean',
+          description: 'Found category deleted'
+        }
+      },
+      example: {
+        id: '16874008-8915-4d53-9239-3913f7ee2089',
+        title: 'Test title',
+        createdAt: '2025-02-10T13:00:27.440Z',
+        updatedAt: '2025-02-10T13:00:27.440Z',
+        deleted: false
+      }
+    }
+  }
+
+  return ApiDocsEndpoint(metadata)
+}

--- a/packages/server/src/services/category/decorator/custom-docs/get-category.decorator.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/get-category.decorator.ts
@@ -18,36 +18,52 @@ export const DocsGetCategory = () => {
       }
     },
     response: {
-      type: 'object',
+      type: 'array',
       properties: {
         id: {
           type: 'string',
-          description: '카테고리 ID'
+          description: 'Found category ID'
         },
         title: {
           type: 'string',
-          description: '카테고리 제목'
+          description: 'Found category title'
         },
         createdAt: {
           type: 'string',
-          description: '생성 일시'
+          description: 'Found category createdAt'
         },
         updatedAt: {
           type: 'string',
-          description: '수정 일시'
+          description: 'Found category updatedAt'
         },
         deleted: {
           type: 'boolean',
-          description: '삭제된 카테고리 분별'
+          description: 'Found category deleted'
         }
       },
-      example: {
-        id: '16874008-8915-4d53-9239-3913f7ee2089',
-        title: 'Test title',
-        createdAt: '2025-02-10T13:00:27.440Z',
-        updatedAt: '2025-02-10T13:00:27.440Z',
-        deleted: false
-      }
+      example: [
+        {
+          id: '16874008-8915-4d53-9239-3913f7ee2089',
+          title: 'Test title',
+          createdAt: '2025-02-10T13:00:27.440Z',
+          updatedAt: '2025-02-10T13:00:27.440Z',
+          deleted: false
+        },
+        {
+          id: '40874008-8915-4d53-9239-3913f7ee2089',
+          title: 'Test title',
+          createdAt: '2025-02-10T13:00:27.440Z',
+          updatedAt: '2025-02-10T13:00:27.440Z',
+          deleted: false
+        },
+        {
+          id: '98874008-8915-4d53-9239-3913f7ee2089',
+          title: 'Test title',
+          createdAt: '2025-02-10T13:00:27.440Z',
+          updatedAt: '2025-02-10T13:00:27.440Z',
+          deleted: false
+        }
+      ]
     }
   }
 


### PR DESCRIPTION
This pull request includes several changes to the API documentation and metadata for category-related endpoints. The main changes involve updating the response structure and adding new fields to the metadata.

### Updates to API documentation and metadata:

* [`packages/server/src/common/types/api-docs.type.ts`](diffhunk://#diff-f424573d1651dc6578e317ae0f3d479baee0f072ed91efcc3f99615485673c7eL105-R107): Modified the `example` property in the `EndpointDecoratorMetadata` interface to accept either a single record or an array of records.

* `packages/server/src/services/category/decorator/custom-docs/create-category.decorator.ts`: 
  * Added the `deleted` field to the `response` properties.
  * Updated the descriptions of the response properties to be more descriptive and changed the example values.

* [`packages/server/src/services/category/decorator/custom-docs/get-category-by-id.decorator.ts`](diffhunk://#diff-643c4c582dce30ac533ba83ada71522daa71eea07d34b7cbc8e5a8bbe5d3a944R1-R55): Added a new decorator for the `get-category-by-id` endpoint, including metadata for `params` and `response` properties.

* `packages/server/src/services/category/decorator/custom-docs/get-category.decorator.ts`: 
  * Changed the `response` type from `object` to `array`.
  * Updated the descriptions of the response properties and modified the example to include multiple records.