### PR TITLE
Add update category documentation decorator

### DIFF
--- a/packages/server/src/services/category/category.controller.ts
+++ b/packages/server/src/services/category/category.controller.ts
@@ -21,7 +21,8 @@ import {
   SwaggerUpdateCategory,
   SwaggerDeleteCategory,
   DocsCreateCategory,
-  DocsGetCategory
+  DocsGetCategory,
+  DocsUpdateCategory
 } from './decorator'
 import { ValidateIdParamDTO } from '../common'
 
@@ -57,6 +58,7 @@ export class CategoryController {
   }
 
   @Patch(':categoryId')
+  @DocsUpdateCategory()
   @SwaggerUpdateCategory()
   async updateCategory(
     @ValidateIdParamDTO() idParamsDto: CategoryIdParamsDto,

--- a/packages/server/src/services/category/category.controller.ts
+++ b/packages/server/src/services/category/category.controller.ts
@@ -22,7 +22,8 @@ import {
   SwaggerDeleteCategory,
   DocsCreateCategory,
   DocsGetCategory,
-  DocsUpdateCategory
+  DocsUpdateCategory,
+  DocsGetCategoryById
 } from './decorator'
 import { ValidateIdParamDTO } from '../common'
 
@@ -51,6 +52,7 @@ export class CategoryController {
   }
 
   @Get(':categoryId')
+  @DocsGetCategoryById()
   @SwaggerGetCategoryById()
   async getCategoryById(@ValidateIdParamDTO() getCategoryDto: CategoryIdParamsDto): Promise<DefaultCategoryResponseType> {
     const { categoryId } = getCategoryDto

--- a/packages/server/src/services/category/decorator/custom-docs/index.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/index.ts
@@ -1,2 +1,3 @@
 export * from './create-category.decorator'
 export * from './get-category.decorator'
+export * from './update-category.decorator'

--- a/packages/server/src/services/category/decorator/custom-docs/index.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/index.ts
@@ -1,3 +1,4 @@
 export * from './create-category.decorator'
 export * from './get-category.decorator'
+export * from './get-category-by-id.decorator'
 export * from './update-category.decorator'

--- a/packages/server/src/services/category/decorator/custom-docs/update-category.decorator.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/update-category.decorator.ts
@@ -1,0 +1,56 @@
+import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'src/common'
+
+export const DocsUpdateCategory = () => {
+  const metadata: EndpointDecoratorMetadata<{
+    params: 'categoryId'
+    response: 'id' | 'title' | 'createdAt' | 'updatedAt' | 'deleted'
+  }> = {
+    description: 'Update a category you want',
+    request: {
+      params: {
+        type: 'string',
+        properties: {
+          categoryId: {
+            type: 'string',
+            description: 'Target category id that you want update'
+          }
+        },
+        required: ['categoryId']
+      }
+    },
+    response: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'category ID'
+        },
+        title: {
+          type: 'string',
+          description: 'Updated category title'
+        },
+        createdAt: {
+          type: 'string',
+          description: 'category createdAt'
+        },
+        updatedAt: {
+          type: 'string',
+          description: 'Updated category updatedAt'
+        },
+        deleted: {
+          type: 'boolean',
+          description: 'category deleted'
+        }
+      },
+      example: {
+        id: '98874008-8915-4d53-9239-3913f7ee2089',
+        title: 'Test title',
+        createdAt: '2025-02-10T13:00:27.440Z',
+        updatedAt: '2025-02-10T13:00:27.440Z',
+        deleted: false
+      }
+    }
+  }
+
+  return ApiDocsEndpoint(metadata)
+}


### PR DESCRIPTION
This pull request introduces new decorators and updates existing ones in the `category` service to enhance the documentation of API endpoints. The changes include adding new decorators for updating a category and retrieving a category by its ID, as well as updating the controller to use these new decorators.

New decorators and updates:

* [`packages/server/src/services/category/category.controller.ts`](diffhunk://#diff-1664ad043f2659061e21aaa2434e3fd366e45349893a416d8925421c5e93269dR55-R63): Added `DocsUpdateCategory` and `DocsGetCategoryById` decorators to the respective methods in the `CategoryController` class.
* [`packages/server/src/services/category/decorator/custom-docs/index.ts`](diffhunk://#diff-c75451c74517d98f77f94159216394ff5ac1f78e9d6667efbe72da2cd9fd1644R3-R4): Exported the new decorators `get-category-by-id.decorator` and `update-category.decorator`.
* [`packages/server/src/services/category/decorator/custom-docs/update-category.decorator.ts`](diffhunk://#diff-61a4a0e6d822b1e877ed6f13730efd86ff6eb4b4f0cb40abf8218f4f059963e1R1-R56): Added a new decorator `DocsUpdateCategory` to document the update category endpoint.
* [`packages/server/src/services/category/category.controller.ts`](diffhunk://#diff-1664ad043f2659061e21aaa2434e3fd366e45349893a416d8925421c5e93269dL24-R26): Updated the import statement to include the new decorators `DocsUpdateCategory` and `DocsGetCategoryById`.