### PR TITLE
Add custom documentation for createTodolist, getTodolist endpoint

### DIFF
--- a/packages/server/src/services/todolist/decorator/custom-docs/create-todolist.decorator.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/create-todolist.decorator.ts
@@ -1,0 +1,70 @@
+import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'src/common'
+
+export const DocsCreateTodolist = () => {
+  const metadata: EndpointDecoratorMetadata<{
+    body: 'title' | 'categoryId'
+    response: 'id' | 'categoryId' | 'title' | 'checked' | 'order' | 'createdAt' | 'updatedAt'
+  }> = {
+    description: 'Create a new todolist',
+    request: {
+      body: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Write title of todolist create you want'
+          },
+          categoryId: {
+            type: 'string',
+            description: 'The location category ID for which you want to create a todolist'
+          }
+        },
+        required: ['title']
+      }
+    },
+    response: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Created category ID'
+        },
+        categoryId: {
+          type: 'string',
+          description: 'The location category ID for which you want to create a todolist'
+        },
+        title: {
+          type: 'string',
+          description: 'Created todolist title'
+        },
+        checked: {
+          type: 'boolean',
+          description: 'Check todolist completion status'
+        },
+        createdAt: {
+          type: 'string',
+          description: 'Created todolist createdAt'
+        },
+        updatedAt: {
+          type: 'string',
+          description: 'Created todolist updatedAt'
+        },
+        order: {
+          type: 'number',
+          description: `The order of the generated todolists`
+        }
+      },
+      example: {
+        id: 'ea2a1198-9b29-4258-9021-409b81f57caf',
+        categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+        title: 'create test todolist',
+        checked: false,
+        order: 13,
+        createdAt: '2025-02-11T09:30:08.938Z',
+        updatedAt: '2025-02-11T09:30:08.938Z'
+      }
+    }
+  }
+
+  return ApiDocsEndpoint(metadata)
+}

--- a/packages/server/src/services/todolist/decorator/custom-docs/get-todolist.decorator.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/get-todolist.decorator.ts
@@ -1,0 +1,74 @@
+import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'src/common'
+
+export const DocsGetTodolist = () => {
+  const metadata: EndpointDecoratorMetadata<{
+    response: 'id' | 'categoryId' | 'title' | 'checked' | 'order' | 'createdAt' | 'updatedAt'
+  }> = {
+    description: '',
+    request: {},
+    response: {
+      type: 'array',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Created category ID'
+        },
+        categoryId: {
+          type: 'string',
+          description: 'The location category ID for which you want to create a todolist'
+        },
+        title: {
+          type: 'string',
+          description: 'Created todolist title'
+        },
+        checked: {
+          type: 'boolean',
+          description: 'Check todolist completion status'
+        },
+        createdAt: {
+          type: 'string',
+          description: 'Created todolist createdAt'
+        },
+        updatedAt: {
+          type: 'string',
+          description: 'Created todolist updatedAt'
+        },
+        order: {
+          type: 'number',
+          description: `The order of the generated todolists`
+        }
+      },
+      example: [
+        {
+          id: 'ea2a1198-9b29-4258-9021-409b81f57caf',
+          categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+          title: 'create test todolist',
+          checked: false,
+          order: 1,
+          createdAt: '2025-02-11T09:30:08.938Z',
+          updatedAt: '2025-02-11T09:30:08.938Z'
+        },
+        {
+          id: '252a1198-9b29-4258-9021-409b81f57caf',
+          categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+          title: 'create test todolist',
+          checked: false,
+          order: 2,
+          createdAt: '2025-02-11T09:30:08.938Z',
+          updatedAt: '2025-02-11T09:30:08.938Z'
+        },
+        {
+          id: '132a1198-9b29-4258-9021-409b81f57caf',
+          categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+          title: 'create test todolist',
+          checked: false,
+          order: 3,
+          createdAt: '2025-02-11T09:30:08.938Z',
+          updatedAt: '2025-02-11T09:30:08.938Z'
+        }
+      ]
+    }
+  }
+
+  return ApiDocsEndpoint(metadata)
+}

--- a/packages/server/src/services/todolist/decorator/custom-docs/index.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/index.ts
@@ -1,1 +1,2 @@
 export * from './create-todolist.decorator'
+export * from './get-todolist.decorator'

--- a/packages/server/src/services/todolist/decorator/custom-docs/index.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/index.ts
@@ -1,0 +1,1 @@
+export * from './create-todolist.decorator'

--- a/packages/server/src/services/todolist/todolist.controller.ts
+++ b/packages/server/src/services/todolist/todolist.controller.ts
@@ -25,7 +25,7 @@ import {
   SwaggerUpdateTodolistOrder
 } from './decorator'
 import { CategoryIdParamsDto, ValidateIdParamDTO } from '../common'
-import { DocsCreateTodolist } from './decorator/custom-docs'
+import { DocsCreateTodolist, DocsGetTodolist } from './decorator/custom-docs'
 
 @ApiTags('Todolist')
 @Controller('todolist')
@@ -40,6 +40,7 @@ export class TodolistController {
   }
 
   @Get()
+  @DocsGetTodolist()
   @SwaggerGetTodolist()
   async getTodolists(): Promise<GetTodolistsResponseType> {
     return this.todolistService.getTodolists()

--- a/packages/server/src/services/todolist/todolist.controller.ts
+++ b/packages/server/src/services/todolist/todolist.controller.ts
@@ -25,6 +25,7 @@ import {
   SwaggerUpdateTodolistOrder
 } from './decorator'
 import { CategoryIdParamsDto, ValidateIdParamDTO } from '../common'
+import { DocsCreateTodolist } from './decorator/custom-docs'
 
 @ApiTags('Todolist')
 @Controller('todolist')
@@ -32,6 +33,7 @@ export class TodolistController {
   constructor(private todolistService: TodolistService) {}
 
   @Post()
+  @DocsCreateTodolist()
   @SwaggerCreateTodolist()
   async createTodolist(@ValidateCreateTodolistDTO() createTodolistDto: CreateTodolistDto): Promise<TodolistResponseType> {
     return this.todolistService.createTodolist(createTodolistDto)


### PR DESCRIPTION
This pull request introduces new API documentation decorators for the todolist service, specifically for creating and retrieving todolists. The changes include the addition of new decorators and their integration into the todolist controller.

New API documentation decorators:

* Added `DocsCreateTodolist` decorator to document the API endpoint for creating a new todolist. This includes details about the request body and response properties. (`packages/server/src/services/todolist/decorator/custom-docs/create-todolist.decorator.ts`)
* Added `DocsGetTodolist` decorator to document the API endpoint for retrieving todolists. This includes details about the response properties and example responses. (`packages/server/src/services/todolist/decorator/custom-docs/get-todolist.decorator.ts`)
* Exported the newly created decorators from the `index.ts` file in the `custom-docs` directory. (`packages/server/src/services/todolist/decorator/custom-docs/index.ts`)

Integration into the todolist controller:

* Imported `DocsCreateTodolist` and `DocsGetTodolist` decorators into the `todolist.controller.ts` file. (`packages/server/src/services/todolist/todolist.controller.ts`)
* Applied `DocsCreateTodolist` decorator to the `createTodolist` method in the `TodolistController` class. (`packages/server/src/services/todolist/todolist.controller.ts`)
* Applied `DocsGetTodolist` decorator to the `getTodolists` method in the `TodolistController` class. (`packages/server/src/services/todolist/todolist.controller.ts`)