### PR TITLE
Add custom documentation for getTodolistById, getTodolistByDate endpoint

### DIFF
--- a/packages/server/src/services/todolist/decorator/custom-docs/get-todolist-by-date.decorator.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/get-todolist-by-date.decorator.ts
@@ -1,0 +1,88 @@
+import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'src/common'
+
+export const DocsGetTodolistByDate = () => {
+  const metadata: EndpointDecoratorMetadata<{
+    query: 'checked'
+    params: 'categoryId'
+    response: 'data' | 'total'
+  }> = {
+    description: '',
+    request: {
+      query: {
+        type: 'boolean',
+        properties: {
+          checked: {
+            type: 'boolean',
+            description: 'A status value that distinguishes completed from incomplete todolist'
+          }
+        }
+      },
+      params: {
+        type: 'string',
+        properties: {
+          categoryId: {
+            type: 'string',
+            description: `The location category's id for which you find todolist's`
+          }
+        }
+      }
+    },
+    response: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'array',
+          description: 'Contains a list of todolist that were modified or completed on a specific date.'
+        },
+        total: {
+          type: 'number',
+          description: 'The number of data that fits the date.'
+        }
+      },
+      example: {
+        data: [
+          {
+            date: '2025-02-02',
+            todolists: [
+              {
+                id: '535edc91-2d9a-404c-a400-175a8e5b2a08',
+                categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+                title: 'changed',
+                checked: true,
+                order: 12,
+                createdAt: '2025-02-02T23:46:46.529Z',
+                updatedAt: '2025-02-02T23:46:54.255Z'
+              },
+              {
+                id: 'c62af2fe-4f20-4ed4-8242-ea4deb243e05',
+                categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+                title: 'somethin',
+                checked: true,
+                order: 11,
+                createdAt: '2025-02-02T23:46:27.215Z',
+                updatedAt: '2025-02-02T23:46:28.977Z'
+              }
+            ]
+          },
+          {
+            date: '2025-01-31',
+            todolists: [
+              {
+                id: '2a9441d7-b8c9-4e03-960f-10215801751a',
+                categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+                title: 'Wabirubi dupdup!!!',
+                checked: true,
+                order: 0,
+                createdAt: '2025-01-22T03:05:22.323Z',
+                updatedAt: '2025-01-31T23:26:47.174Z'
+              }
+            ]
+          }
+        ],
+        total: 2
+      }
+    }
+  }
+
+  return ApiDocsEndpoint(metadata)
+}

--- a/packages/server/src/services/todolist/decorator/custom-docs/get-todolist-by-id.decorator.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/get-todolist-by-id.decorator.ts
@@ -1,0 +1,95 @@
+import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'src/common'
+
+export const DocsGetTodolistById = () => {
+  const metadata: EndpointDecoratorMetadata<{
+    query: 'checked'
+    params: 'categoryId'
+    response: 'id' | 'categoryId' | 'title' | 'checked' | 'order' | 'createdAt' | 'updatedAt'
+  }> = {
+    description: '',
+    request: {
+      query: {
+        type: 'boolean',
+        properties: {
+          checked: {
+            type: 'boolean',
+            description: 'A status value that distinguishes completed from incomplete todolist'
+          }
+        }
+      },
+      params: {
+        type: 'string',
+        properties: {
+          categoryId: {
+            type: 'string',
+            description: `The location category's id for which you find todolist's`
+          }
+        }
+      }
+    },
+    response: {
+      type: 'array',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Created category ID'
+        },
+        categoryId: {
+          type: 'string',
+          description: 'The location category ID for which you want to create a todolist'
+        },
+        title: {
+          type: 'string',
+          description: 'Created todolist title'
+        },
+        checked: {
+          type: 'boolean',
+          description: 'Check todolist completion status'
+        },
+        createdAt: {
+          type: 'string',
+          description: 'Created todolist createdAt'
+        },
+        updatedAt: {
+          type: 'string',
+          description: 'Created todolist updatedAt'
+        },
+        order: {
+          type: 'number',
+          description: `The order of the generated todolists`
+        }
+      },
+      example: [
+        {
+          id: 'ea2a1198-9b29-4258-9021-409b81f57caf',
+          categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+          title: 'create test todolist',
+          checked: false,
+          order: 1,
+          createdAt: '2025-02-11T09:30:08.938Z',
+          updatedAt: '2025-02-11T09:30:08.938Z'
+        },
+        {
+          id: '252a1198-9b29-4258-9021-409b81f57caf',
+          categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+          title: 'create test todolist',
+          checked: false,
+          order: 2,
+          createdAt: '2025-02-11T09:30:08.938Z',
+          updatedAt: '2025-02-11T09:30:08.938Z'
+        },
+        {
+          id: '132a1198-9b29-4258-9021-409b81f57caf',
+          categoryId: 'f144cc78-34d9-4d0a-9e95-48cf7102dce3',
+          title: 'create test todolist',
+          checked: false,
+          order: 3,
+          createdAt: '2025-02-11T09:30:08.938Z',
+          updatedAt: '2025-02-11T09:30:08.938Z'
+        }
+      ]
+    }
+  }
+
+  return ApiDocsEndpoint(metadata)
+}

--- a/packages/server/src/services/todolist/decorator/custom-docs/get-todolist.decorator.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/get-todolist.decorator.ts
@@ -15,7 +15,7 @@ export const DocsGetTodolist = () => {
         },
         categoryId: {
           type: 'string',
-          description: 'The location category ID for which you want to create a todolist'
+          description: 'The location category ID'
         },
         title: {
           type: 'string',

--- a/packages/server/src/services/todolist/decorator/custom-docs/index.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/index.ts
@@ -1,2 +1,3 @@
 export * from './create-todolist.decorator'
 export * from './get-todolist.decorator'
+export * from './get-todolist-by-id.decorator'

--- a/packages/server/src/services/todolist/decorator/custom-docs/index.ts
+++ b/packages/server/src/services/todolist/decorator/custom-docs/index.ts
@@ -1,3 +1,4 @@
 export * from './create-todolist.decorator'
 export * from './get-todolist.decorator'
 export * from './get-todolist-by-id.decorator'
+export * from './get-todolist-by-date.decorator'

--- a/packages/server/src/services/todolist/todolist.controller.ts
+++ b/packages/server/src/services/todolist/todolist.controller.ts
@@ -25,7 +25,7 @@ import {
   SwaggerUpdateTodolistOrder
 } from './decorator'
 import { CategoryIdParamsDto, ValidateIdParamDTO } from '../common'
-import { DocsCreateTodolist, DocsGetTodolist, DocsGetTodolistById } from './decorator/custom-docs'
+import { DocsCreateTodolist, DocsGetTodolist, DocsGetTodolistByDate, DocsGetTodolistById } from './decorator/custom-docs'
 
 @ApiTags('Todolist')
 @Controller('todolist')
@@ -64,6 +64,7 @@ export class TodolistController {
   }
 
   @Get('/dates/:categoryId')
+  @DocsGetTodolistByDate()
   @SwaggerGetTodolistByDate()
   async getTodolistsByDate(
     @ValidateIdParamDTO() getCategoryDto: CategoryIdParamsDto,

--- a/packages/server/src/services/todolist/todolist.controller.ts
+++ b/packages/server/src/services/todolist/todolist.controller.ts
@@ -25,7 +25,7 @@ import {
   SwaggerUpdateTodolistOrder
 } from './decorator'
 import { CategoryIdParamsDto, ValidateIdParamDTO } from '../common'
-import { DocsCreateTodolist, DocsGetTodolist } from './decorator/custom-docs'
+import { DocsCreateTodolist, DocsGetTodolist, DocsGetTodolistById } from './decorator/custom-docs'
 
 @ApiTags('Todolist')
 @Controller('todolist')
@@ -47,6 +47,7 @@ export class TodolistController {
   }
 
   @Get(':categoryId')
+  @DocsGetTodolistById()
   @SwaggerGetTodolistById()
   async getTodolistsByCategoryId(
     @ValidateIdParamDTO() getCategoryDto: CategoryIdParamsDto,


### PR DESCRIPTION
This pull request introduces new API documentation decorators for the `todolist` service and updates the controller to use these decorators. The most important changes include adding decorators for fetching todolists by date and by ID, and updating the controller to use these new decorators.

### New API Documentation Decorators:

* Added `DocsGetTodolistByDate` decorator to document the endpoint for fetching todolists by date. This includes metadata for query parameters, request parameters, and response structure.
* Added `DocsGetTodolistById` decorator to document the endpoint for fetching todolists by ID. This includes metadata for query parameters, request parameters, and response structure.

### Controller Updates:

* Updated `TodolistController` to use the new `DocsGetTodolistById` decorator for the endpoint that fetches todolists by ID.
* Updated `TodolistController` to use the new `DocsGetTodolistByDate` decorator for the endpoint that fetches todolists by date.

### Documentation Export:

* Updated `index.ts` to export the new decorators `DocsGetTodolistById` and `DocsGetTodolistByDate`.

### Minor Changes:

* Simplified the description in the existing `DocsGetTodolist` decorator.
* Updated imports in `todolist.controller.ts` to include the new decorators.