### PR TITLE
Update category documentation to include body parameter

### DIFF
--- a/packages/server/src/services/category/decorator/custom-docs/update-category.docs.ts
+++ b/packages/server/src/services/category/decorator/custom-docs/update-category.docs.ts
@@ -2,8 +2,9 @@ import { ApiDocsEndpoint, EndpointDecoratorMetadata } from 'doke'
 
 export const DocsUpdateCategory = () => {
   const metadata: EndpointDecoratorMetadata<{
-    params: 'categoryId'
     headers: 'Content-Type'
+    params: 'categoryId'
+    body: 'title'
     response: 'id' | 'title' | 'createdAt' | 'updatedAt' | 'deleted'
   }> = {
     description: `This endpoint updates the properties of a specific category identified by its unique categoryId parameter.
@@ -17,6 +18,15 @@ export const DocsUpdateCategory = () => {
             type: 'string',
             description: 'Target category id that you want update',
             required: true
+          }
+        }
+      },
+      body: {
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Write title of category that you want update',
+            required: false
           }
         }
       },


### PR DESCRIPTION
This pull request includes updates to the `DocsUpdateCategory` function in the `update-category.docs.ts` file to enhance the API documentation for updating a category. The most important changes include adding a new `body` parameter and updating the metadata structure.

Enhancements to API documentation:

* [`packages/server/src/services/category/decorator/custom-docs/update-category.docs.ts`](diffhunk://#diff-d2c1694d47451145ba29c968b2f6cbbcc8c8fd1b4508a68755c6e2bad7e71ba1L5-R7): Added a new `body` parameter to the metadata, specifying the `title` property for updating the category title.
* [`packages/server/src/services/category/decorator/custom-docs/update-category.docs.ts`](diffhunk://#diff-d2c1694d47451145ba29c968b2f6cbbcc8c8fd1b4508a68755c6e2bad7e71ba1R24-R32): Updated the `DocsUpdateCategory` function to include the `body` properties in the API documentation, detailing the `title` property type and description.