### PR TITLE
Update file path in generate-docs.ts, yarn.lock

### DIFF
--- a/packages/server/src/utils/generate-docs.ts
+++ b/packages/server/src/utils/generate-docs.ts
@@ -12,7 +12,7 @@ async function generateDocs() {
   }
 
   const discoveryService = app.get(DiscoveryService)
-  await new ApiDocsGenerator(info, '/Users/benny/Desktop/projects/doke-ui/', discoveryService).generate()
+  await new ApiDocsGenerator(info, '/Users/benny/Desktop/projects/todolist/packages/server', discoveryService).generate()
   await app.close()
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5228,6 +5228,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+doke-nest@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/doke-nest/-/doke-nest-1.0.0.tgz#32fd7dcce050ef19b4b7b8abf9649add9cec42b8"
+  integrity sha512-EBjw1uK6IjTn09o6f/8Iri8/E/ceJQVU0ZDYZHzQ+rFjM4JJklPlTUalPl5i//wOMxRHmY7Cy6flhiA3szp11A==
+
 dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"


### PR DESCRIPTION
This pull request includes a small but important change to the `generateDocs` function in the `packages/server/src/utils/generate-docs.ts` file. The change updates the file path used by the `ApiDocsGenerator`.

* [`packages/server/src/utils/generate-docs.ts`](diffhunk://#diff-81d2ea23b8db9e46e49d4aa36dad4d31653211301c86630f26afdfc044930d3fL15-R15): Updated the file path in the `ApiDocsGenerator` constructor to point to the correct project directory.