### PR TITLE
Update doke-nest version to 1.0.1 and remove unnecessary file path in generate-docs.ts

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,7 +34,7 @@
     "@nestjs/swagger": "^7.4.2",
     "@nestjs/typeorm": "^10.0.2",
     "@types/uuid": "^10.0.0",
-    "doke-nest": "^1.0.0",
+    "doke-nest": "^1.0.1",
     "dotenv": "^16.4.5",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/packages/server/src/utils/generate-docs.ts
+++ b/packages/server/src/utils/generate-docs.ts
@@ -12,7 +12,7 @@ async function generateDocs() {
   }
 
   const discoveryService = app.get(DiscoveryService)
-  await new ApiDocsGenerator(info, '/Users/benny/Desktop/projects/todolist/packages/server', discoveryService).generate()
+  await new ApiDocsGenerator(info, discoveryService).generate()
   await app.close()
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5228,10 +5228,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-doke-nest@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/doke-nest/-/doke-nest-1.0.0.tgz#32fd7dcce050ef19b4b7b8abf9649add9cec42b8"
-  integrity sha512-EBjw1uK6IjTn09o6f/8Iri8/E/ceJQVU0ZDYZHzQ+rFjM4JJklPlTUalPl5i//wOMxRHmY7Cy6flhiA3szp11A==
+doke-nest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/doke-nest/-/doke-nest-1.0.1.tgz#79545f9f420a21d9e6ecca96e3ccc4fe847da007"
+  integrity sha512-5xU/nkWWeFIVMxRNRk7qBYH67noN6X/GDC1kQGF4ekcPYu68ek3JXx5B40/iwKT6oV9vJgubisUOP/4XWxUhKA==
 
 dom-accessibility-api@^0.5.9:
   version "0.5.16"


### PR DESCRIPTION
This pull request includes updates to a package version and a simplification in the `generateDocs` function.

Dependency update:

* [`packages/server/package.json`](diffhunk://#diff-92fadee1dfb23b20d6b0f6557a3ea0b8a231a7591db73f9f37772383bd0575d9L37-R37): Updated the version of the `doke-nest` package from `^1.0.0` to `^1.0.1`.

Code simplification:

* [`packages/server/src/utils/generate-docs.ts`](diffhunk://#diff-81d2ea23b8db9e46e49d4aa36dad4d31653211301c86630f26afdfc044930d3fL15-R15): Simplified the `generateDocs` function by removing a hardcoded file path parameter from the `ApiDocsGenerator` instantiation.… generate-docs.ts